### PR TITLE
Victory conditions: max-rounds tiebreak, end-game overlay (#22, #33, #34)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,12 @@ jobs:
           ../Godot_v4.6.2-stable_linux.x86_64 --headless -s tests/test_runner.gd --quit
         timeout-minutes: 2
 
+      - name: Run game engine tests (v17 order state machine + combat + victory)
+        working-directory: godot
+        run: |
+          ../Godot_v4.6.2-stable_linux.x86_64 --headless -s tests/test_game_engine.gd --quit
+        timeout-minutes: 2
+
       - name: Validate UI scenes
         working-directory: godot
         run: |

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,8 +1,8 @@
 # Turnip28 Simulator - Project Memory
 
-**Last Updated:** 2026-04-19
-**Current state:** v17 order state machine merged to `main` (PR #32, commit `f5fa929`)
-**Active branch:** none — working on `main`
+**Last Updated:** 2026-04-20
+**Current state:** victory-conditions work complete, PR [#35](https://github.com/rpmcdougall/turnipsim/pull/35) **open on `feature/victory-conditions`** awaiting merge. Closes #22, #33, #34.
+**Active branch:** `feature/victory-conditions` (pushed; don't start new work until merged)
 
 ## Phase status
 
@@ -16,7 +16,7 @@
 | 4 — Battle engine (initial) | ✅ | PR #26 — later replaced by v17 order state machine (PR #32) |
 | 4.5 — v17 data model | ✅ | PR #30 (issue #27) |
 | 4.5 — v17 order mechanics | ✅ | **PR #32 (issue #31)** — this session |
-| 5 — Polish | 🚧 | #22 In Progress (partial victory conditions), #21 Todo (visual polish) |
+| 5 — Polish | 🚧 | #22 ✅ on PR #35 (max-rounds tiebreak, end-game overlay), #21 Todo (visual polish — blocks comfortable play-testing per 2026-04-20 notes), #36 Todo (objectives, replaces placeholder tiebreak) |
 | 5b — Army submission UI | 🚧 | #28 Todo — lobby currently picks random preset; real builder not yet implemented (old #20 was a placeholder) |
 | 6 — Deploy | ⬜ | #23–25 Todo |
 | 7 — Cult mechanics | ⬜ | #29 Todo |
@@ -42,7 +42,7 @@ godot/
 │   └── network_client.gd          # Signals + RPC interface
 └── tests/
     ├── test_runner.gd             # 19 tests — types, ruleset, roster validation
-    └── test_game_engine.gd        # 48 tests — order state machine, combat, victory
+    └── test_game_engine.gd        # 55 tests — order state machine, combat, victory, fizzle paths
 ```
 
 **Key design decisions:**
@@ -82,7 +82,7 @@ export GODOT="/Applications/Godot.app/Contents/MacOS/Godot"  # macOS
 # Automated tests
 cd godot/
 $GODOT --headless -s tests/test_runner.gd       # 19 tests
-$GODOT --headless -s tests/test_game_engine.gd  # 48 tests
+$GODOT --headless -s tests/test_game_engine.gd  # 55 tests
 
 # Full local stack (headless server + 2 windowed clients)
 scripts/test-stack.sh
@@ -105,20 +105,23 @@ Per-process logs land in `test-logs/` (gitignored). Ctrl+C tears everything down
 - `entry.gd:6/8` benign warning — `change_scene_to_file()` in `_ready()` needs to be `call_deferred`'d
 - Fresh-clone tests fail until `$GODOT --editor --quit` builds the script class cache once
 - `docs/wiki/Phase-4-UI-{Programmatic,Tasks}.md` are historical checkpoint-style docs; candidates for archival
+- **Zombie server on port 9999** — `test-stack.sh` doesn't detect a stale previously-launched server; new stack's server silently fails to bind while clients attach to the old one (ghost-code behavior). Workaround: `taskkill //F //IM Godot_v4.6.2-stable_win64.exe` before relaunch. Candidate for a small script hardening pass.
+- **Max-rounds tiebreak is a placeholder** — v17 actually scores by objectives captured (#36). Current alive-units → model-count tiebreak is stand-in logic, marked `TODO(objectives)` in `game_engine.gd:check_victory`.
 
 ## Checkpoint history
 
 - `memory/checkpoint-2026-04-17-phases-1-2-3.md`
 - `memory/checkpoint-2026-04-17-phase-3b-4.md`
 - `memory/checkpoint-2026-04-18-phase-4-ui.md`
-- `memory/checkpoint-2026-04-19-order-mechanics.md` ← this session
+- `memory/checkpoint-2026-04-19-order-mechanics.md`
+- `memory/checkpoint-2026-04-20-victory-conditions.md` ← this session
 
 ## Next pickup
 
-Three independent options:
+Merge PR #35 first. Then, per agreement this session: **#28 roster builder** is next (current lobby picks a random preset — low player value). After that:
 
-1. **#22** — finish victory conditions (objectives, victory/defeat UI, end-of-game summary, new-game button)
-2. **#21** — Phase 5 visual polish (unit sprites vs ColorRects, terrain)
-3. **Phase 6** — export presets + deploy (#23–25)
+- **#21** — Phase 5 visual polish (grid targeting visibility flagged as friction during manual play on 2026-04-20, commented on issue)
+- **#36** — v17 objectives (replaces the placeholder max-rounds tiebreak with real scoring)
+- **Phase 6** — export presets + deploy (#23–25)
 
-Ask before picking; no dependencies between them.
+No strict dependencies between #28, #21, and #36 — pick whichever fits the session.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -17,7 +17,7 @@
 | 4.5 — v17 data model | ✅ | PR #30 (issue #27) |
 | 4.5 — v17 order mechanics | ✅ | **PR #32 (issue #31)** — this session |
 | 5 — Polish | 🚧 | #22 In Progress (partial victory conditions), #21 Todo (visual polish) |
-| 5b — Army submission UI | ✅ | Issue #20 Done |
+| 5b — Army submission UI | 🚧 | #28 Todo — lobby currently picks random preset; real builder not yet implemented (old #20 was a placeholder) |
 | 6 — Deploy | ⬜ | #23–25 Todo |
 | 7 — Cult mechanics | ⬜ | #29 Todo |
 

--- a/docs/wiki/Manual-Testing-Guide.md
+++ b/docs/wiki/Manual-Testing-Guide.md
@@ -13,7 +13,7 @@ If these fail, stop — fix them before bothering with a live stack.
 ```bash
 cd godot/
 $GODOT --headless -s tests/test_runner.gd         # Phase 1 — 19 tests
-$GODOT --headless -s tests/test_game_engine.gd    # Engine — 48 tests
+$GODOT --headless -s tests/test_game_engine.gd    # Engine — 51 tests
 ```
 
 Both should report `Failed: 0`.
@@ -84,11 +84,37 @@ On success the turn either passes to the opposing seat (if they still have unord
 
 ### 4. Victory
 
-- Elimination: all of a seat's units dead → other seat wins.
-- Headless Chicken: all of a seat's Snobs dead → instant loss for that seat.
-- Max rounds (4) elapsed with both sides alive → draw by current rules (Phase 5 will add objectives).
+Three end conditions, all surfacing via the same `_send_game_ended` broadcast:
 
-Server broadcasts `_send_game_ended`; both clients display `VICTORY! / DEFEAT! / DRAW!` in the turn banner.
+| Condition | Winner | Reason string contains |
+|---|---|---|
+| One seat has no living units (and the other does) | Opposing seat | `"eliminated"` |
+| One seat has no living Snobs | Opposing seat | `"Headless Chicken"` |
+| `current_round > max_rounds` | Tiebreak by alive units, then by total alive models, then draw | `"Time expired"` |
+
+On game end, every client:
+
+1. Turn banner rewrites to `VICTORY / DEFEAT / DRAW — <reason>`.
+2. A **Game Over overlay** appears: large coloured title, reason, rounds played, and surviving-unit counts for both sides.
+3. A **Return to Main Menu** button disconnects the peer and navigates back to `main.tscn`. The other player stays in the battle scene until they click their own button (or you kill the client window).
+
+#### Testing victory paths locally
+
+The fastest way to force each path without an hour-long game:
+
+- **Elimination / Headless Chicken** — during `order_execute`, have the opposing seat volley-fire / charge your weaker units until they're all dead (or all Snobs are dead). Works from a Balanced vs Gunline matchup in 2–3 rounds with lucky rolls.
+- **Max-rounds expiry** — avoid combat for 4 rounds. Pick March every time on both seats. After round 4 ends with units still alive, the overlay should say `"Time expired — ..."` with the correct winner based on alive-unit count (or draw if equal).
+- **Forcing a max-rounds draw** — use `--solo` mode with symmetric rosters on both seats (not possible without a helper), or temporarily edit `state.max_rounds = 1` in `game_engine.gd:_initialize_game_state` and watch the overlay fire after the first round.
+
+#### What to check on the overlay
+
+| Item | Expected |
+|---|---|
+| Title colour | Green for VICTORY, red for DEFEAT, yellow for DRAW |
+| Rounds played | Clamped to `max_rounds` (4), not `current_round` which advances past it |
+| Unit counts | `surviving / total` matches what you see on the board |
+| Return button | Single click → main menu, no stuck state. Running a second `scripts/test-stack.sh` session should reconnect cleanly. |
+| Double-firing | If the server happens to send two game_ended events, only one overlay should show (guarded by `has_node("GameOverOverlay")`) |
 
 ---
 

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -939,16 +939,121 @@ func _on_action_resolved(action: Dictionary, result: Dictionary) -> void:
 
 
 func _on_game_ended(winner_seat: int, reason: String) -> void:
-	var message = ""
+	var outcome := ""
+	var title_color := Color.WHITE
 	if winner_seat == my_seat:
-		message = "VICTORY! " + reason
+		outcome = "VICTORY"
+		title_color = Color(0.4, 0.9, 0.4)
 	elif winner_seat == 0:
-		message = "DRAW! " + reason
+		outcome = "DRAW"
+		title_color = Color(0.85, 0.85, 0.55)
 	else:
-		message = "DEFEAT! " + reason
+		outcome = "DEFEAT"
+		title_color = Color(0.95, 0.45, 0.45)
 
-	turn_banner.text = message
-	_add_log_entry("=== GAME OVER: " + message + " ===")
+	turn_banner.text = "%s — %s" % [outcome, reason]
+	_add_log_entry("=== GAME OVER: %s — %s ===" % [outcome, reason])
+	_show_game_over_overlay(outcome, title_color, reason)
+
+
+func _show_game_over_overlay(outcome: String, title_color: Color, reason: String) -> void:
+	# Guard against double-firing
+	if has_node("GameOverOverlay"):
+		return
+
+	var rounds_played: int = 0
+	var my_units_total: int = 0
+	var my_units_alive: int = 0
+	var enemy_units_total: int = 0
+	var enemy_units_alive: int = 0
+	if current_game_state:
+		# current_round advances past the last completed round; clamp to max_rounds for display
+		rounds_played = mini(current_game_state.current_round, current_game_state.max_rounds)
+		for unit in current_game_state.units:
+			var is_mine := unit.owner_seat == my_seat
+			if is_mine:
+				my_units_total += 1
+				if not unit.is_dead:
+					my_units_alive += 1
+			else:
+				enemy_units_total += 1
+				if not unit.is_dead:
+					enemy_units_alive += 1
+
+	var overlay := ColorRect.new()
+	overlay.name = "GameOverOverlay"
+	overlay.color = Color(0, 0, 0, 0.65)
+	overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	overlay.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(overlay)
+
+	var center := CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	overlay.add_child(center)
+
+	var panel := PanelContainer.new()
+	panel.custom_minimum_size = Vector2(420, 0)
+	center.add_child(panel)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 12)
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 24)
+	margin.add_theme_constant_override("margin_right", 24)
+	margin.add_theme_constant_override("margin_top", 20)
+	margin.add_theme_constant_override("margin_bottom", 20)
+	panel.add_child(margin)
+	margin.add_child(vbox)
+
+	var title := Label.new()
+	title.text = outcome
+	title.add_theme_font_size_override("font_size", 36)
+	title.add_theme_color_override("font_color", title_color)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(title)
+
+	var reason_label := Label.new()
+	reason_label.text = reason
+	reason_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	reason_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	reason_label.custom_minimum_size = Vector2(380, 0)
+	vbox.add_child(reason_label)
+
+	var separator := HSeparator.new()
+	vbox.add_child(separator)
+
+	var stats := VBoxContainer.new()
+	stats.add_theme_constant_override("separation", 4)
+	vbox.add_child(stats)
+
+	var rounds_line := Label.new()
+	rounds_line.text = "Rounds played: %d" % rounds_played
+	stats.add_child(rounds_line)
+
+	var my_line := Label.new()
+	my_line.text = "Your units: %d / %d surviving (%d lost)" % [
+		my_units_alive, my_units_total, my_units_total - my_units_alive
+	]
+	stats.add_child(my_line)
+
+	var enemy_line := Label.new()
+	enemy_line.text = "Enemy units: %d / %d surviving (%d lost)" % [
+		enemy_units_alive, enemy_units_total, enemy_units_total - enemy_units_alive
+	]
+	stats.add_child(enemy_line)
+
+	var button := Button.new()
+	button.text = "Return to Main Menu"
+	button.pressed.connect(_on_return_to_menu_pressed)
+	vbox.add_child(button)
+
+
+func _on_return_to_menu_pressed() -> void:
+	print("[Battle] Returning to main menu")
+	if multiplayer.multiplayer_peer != null:
+		multiplayer.multiplayer_peer = null
+	NetworkManager.reset_seat()
+	get_tree().change_scene_to_file("res://client/main.tscn")
 
 
 func _on_error_received(message: String) -> void:

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -722,13 +722,25 @@ func _render_order_execute_panel() -> void:
 
 	match order_type:
 		"volley_fire":
-			order_execute_instruction.text = "Click an enemy unit to fire."
+			if unit and not _has_valid_enemy_in_range(unit, unit.base_stats.weapon_range):
+				order_execute_instruction.text = "No enemies in range — the volley fizzles."
+				order_execute_confirm_button.text = "Continue (no effect)"
+				order_execute_confirm_button.visible = true
+			else:
+				order_execute_instruction.text = "Click an enemy unit to fire."
+				order_execute_confirm_button.text = "Confirm move (no shot)"
 		"charge":
 			var bonus = current_game_state.current_order_move_bonus
 			var move = unit.base_stats.movement if unit else 0
-			order_execute_instruction.text = "Click enemy to charge (range %d + %d = %d)." % [
-				move, bonus, move + bonus
-			]
+			if unit and not _has_valid_enemy_in_range(unit, move + bonus):
+				order_execute_instruction.text = "No enemies in charge range — the charge fizzles."
+				order_execute_confirm_button.text = "Continue (no effect)"
+				order_execute_confirm_button.visible = true
+			else:
+				order_execute_instruction.text = "Click enemy to charge (range %d + %d = %d)." % [
+					move, bonus, move + bonus
+				]
+				order_execute_confirm_button.text = "Confirm move (no shot)"
 		"march":
 			var bonus = current_game_state.current_order_move_bonus
 			var move = unit.base_stats.movement if unit else 0
@@ -795,10 +807,27 @@ func _on_self_order_pressed(order_type: String) -> void:
 
 
 func _on_execute_confirm_pressed() -> void:
+	var order_type = current_game_state.current_order_type
+	# Volley fire / charge fizzle path — no valid targets in range.
+	if order_type == "volley_fire" or order_type == "charge":
+		_send_execute_order({"fizzle": true})
+		return
 	# Move-and-shoot: commit the staged destination with no target
 	if pending_move_x == -1:
 		return
 	_send_execute_order({"x": pending_move_x, "y": pending_move_y})
+
+
+func _has_valid_enemy_in_range(unit: Types.UnitState, reach: int) -> bool:
+	if reach <= 0:
+		return false
+	for u in current_game_state.units:
+		if u.is_dead or u.owner_seat == unit.owner_seat:
+			continue
+		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
+		if d <= reach:
+			return true
+	return false
 
 
 # =============================================================================

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -750,11 +750,14 @@ func _render_order_execute_panel() -> void:
 		"move_and_shoot":
 			var move = unit.base_stats.movement if unit else 0
 			if pending_move_x == -1:
-				order_execute_instruction.text = "Click destination (max %d cells)." % move
+				order_execute_instruction.text = "Click destination (max %d cells), or Skip to stay put." % move
+				order_execute_confirm_button.text = "Skip (no move, no shot)"
+				order_execute_confirm_button.visible = true
 			else:
-				order_execute_instruction.text = "Destination: (%d,%d).\nClick enemy to shoot, or Confirm to skip." % [
+				order_execute_instruction.text = "Destination: (%d,%d).\nClick enemy to shoot, or Confirm to skip the shot." % [
 					pending_move_x, pending_move_y
 				]
+				order_execute_confirm_button.text = "Confirm move (no shot)"
 				order_execute_confirm_button.visible = true
 
 
@@ -812,8 +815,12 @@ func _on_execute_confirm_pressed() -> void:
 	if order_type == "volley_fire" or order_type == "charge":
 		_send_execute_order({"fizzle": true})
 		return
-	# Move-and-shoot: commit the staged destination with no target
+	# Move-and-shoot: no staged destination → stay put. Otherwise commit.
 	if pending_move_x == -1:
+		var unit = _get_unit_by_id(current_game_state.current_order_unit_id)
+		if not unit:
+			return
+		_send_execute_order({"x": unit.x, "y": unit.y})
 		return
 	_send_execute_order({"x": pending_move_x, "y": pending_move_y})
 

--- a/godot/client/scenes/lobby.gd
+++ b/godot/client/scenes/lobby.gd
@@ -103,8 +103,23 @@ func _disconnect_from_server() -> void:
 	is_connected = false
 	is_in_room = false
 	NetworkManager.reset_seat()  # Clear seat assignment
+	_reset_army_state()
 	status_label.text = "Disconnected"
 	_show_connection_panel()
+
+
+## Clear roster + submission flags so a reconnect/rejoin starts fresh.
+## Without this, has_submitted_army persists and hides the Submit button
+## after joining a new room, leaving the client stuck ready-without-army.
+func _reset_army_state() -> void:
+	my_roster = null
+	has_submitted_army = false
+	if submit_army_button:
+		submit_army_button.disabled = true
+		submit_army_button.visible = false
+	if army_display:
+		for child in army_display.get_children():
+			child.queue_free()
 
 
 func _on_connected_to_server() -> void:
@@ -126,6 +141,7 @@ func _on_server_disconnected() -> void:
 	status_label.text = "Server disconnected"
 	is_connected = false
 	is_in_room = false
+	_reset_army_state()
 	_show_connection_panel()
 
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -454,6 +454,26 @@ static func execute_order(state: Types.GameState, params: Dictionary, dice_resul
 static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, params: Dictionary, dice_results: Array) -> Types.EngineResult:
 	var result = Types.EngineResult.new()
 
+	# Fizzle path: no valid target exists in range. Advance without combat.
+	if params.get("fizzle", false):
+		if _has_valid_volley_target(state, unit):
+			result.error = "Cannot fizzle: valid targets exist in range"
+			return result
+		var fizzled_state = _clone_state(state)
+		_advance_after_order(fizzled_state)
+		fizzled_state.action_log.append({
+			"round": state.current_round,
+			"seat": state.active_seat,
+			"action": "volley_fire_fizzled",
+			"unit_id": unit.id,
+			"unit_type": unit.unit_type,
+			"blundered": state.current_order_blundered
+		})
+		result.success = true
+		result.new_state = fizzled_state
+		result.description = "%s volley fire fizzled (no targets in range)" % unit.unit_type
+		return result
+
 	var target_id = params.get("target_id", "")
 	var target = _find_unit(state, target_id)
 	if not target:
@@ -630,6 +650,26 @@ static func _execute_march(state: Types.GameState, unit: Types.UnitState, params
 
 static func _execute_charge(state: Types.GameState, unit: Types.UnitState, params: Dictionary, dice_results: Array) -> Types.EngineResult:
 	var result = Types.EngineResult.new()
+
+	# Fizzle path: no chargeable enemy in range. Advance without combat.
+	if params.get("fizzle", false):
+		if _has_valid_charge_target(state, unit):
+			result.error = "Cannot fizzle: valid charge targets exist in range"
+			return result
+		var fizzled_state = _clone_state(state)
+		_advance_after_order(fizzled_state)
+		fizzled_state.action_log.append({
+			"round": state.current_round,
+			"seat": state.active_seat,
+			"action": "charge_fizzled",
+			"unit_id": unit.id,
+			"unit_type": unit.unit_type,
+			"blundered": state.current_order_blundered
+		})
+		result.success = true
+		result.new_state = fizzled_state
+		result.description = "%s charge fizzled (no targets in range)" % unit.unit_type
+		return result
 
 	var target_id = params.get("target_id", "")
 	var target = _find_unit(state, target_id)
@@ -978,6 +1018,34 @@ static func _find_unit_in(state: Types.GameState, unit_id: String) -> Types.Unit
 static func _has_unordered_snobs(state: Types.GameState, seat: int) -> bool:
 	for unit in state.units:
 		if unit.owner_seat == seat and unit.is_snob() and not unit.is_dead and not unit.has_ordered:
+			return true
+	return false
+
+
+## Does at least one alive enemy unit sit inside the shooter's weapon range?
+static func _has_valid_volley_target(state: Types.GameState, unit: Types.UnitState) -> bool:
+	var wr: int = unit.base_stats.weapon_range
+	if wr <= 0:
+		return false
+	for u in state.units:
+		if u.is_dead or u.owner_seat == unit.owner_seat:
+			continue
+		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
+		if d <= wr:
+			return true
+	return false
+
+
+## Does at least one alive enemy unit sit inside the charger's M + move_bonus range?
+static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitState) -> bool:
+	var reach: int = unit.base_stats.movement + state.current_order_move_bonus
+	if reach <= 0:
+		return false
+	for u in state.units:
+		if u.is_dead or u.owner_seat == unit.owner_seat:
+			continue
+		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
+		if d <= reach:
 			return true
 	return false
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -911,6 +911,27 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 	if snobs_alive_2 == 0 and snobs_alive_1 > 0:
 		return {"winner": 1, "reason": "Player 2 lost all Snobs (Headless Chicken)"}
 
+	# Time limit reached: tiebreak by surviving units, then by model count
+	if state.current_round > state.max_rounds:
+		if units_alive_1 > units_alive_2:
+			return {"winner": 1, "reason": "Time expired — Player 1 holds the field"}
+		if units_alive_2 > units_alive_1:
+			return {"winner": 2, "reason": "Time expired — Player 2 holds the field"}
+		var models_alive_1: int = 0
+		var models_alive_2: int = 0
+		for unit in state.units:
+			if unit.is_dead:
+				continue
+			if unit.owner_seat == 1:
+				models_alive_1 += unit.model_count
+			else:
+				models_alive_2 += unit.model_count
+		if models_alive_1 > models_alive_2:
+			return {"winner": 1, "reason": "Time expired — Player 1 has more models standing"}
+		if models_alive_2 > models_alive_1:
+			return {"winner": 2, "reason": "Time expired — Player 2 has more models standing"}
+		return {"winner": 0, "reason": "Time expired — the field is contested (Draw)"}
+
 	return {"winner": 0, "reason": ""}
 
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -951,7 +951,10 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 	if snobs_alive_2 == 0 and snobs_alive_1 > 0:
 		return {"winner": 1, "reason": "Player 2 lost all Snobs (Headless Chicken)"}
 
-	# Time limit reached: tiebreak by surviving units, then by model count
+	# Time limit reached: placeholder tiebreak by surviving units, then by
+	# model count. v17's real rule is objective-based scoring (see #36) —
+	# replace this branch once objectives / scenarios are implemented.
+	# TODO(objectives): see https://github.com/rpmcdougall/turnipsim/issues/36
 	if state.current_round > state.max_rounds:
 		if units_alive_1 > units_alive_2:
 			return {"winner": 1, "reason": "Time expired — Player 1 holds the field"}

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -307,9 +307,10 @@ func request_action(action_data: Dictionary) -> void:
 	# Update stored state
 	active_games[room.code] = result.new_state
 
-	# Check victory
+	# Check victory (also handles max-rounds tiebreak / draw)
 	var victory = GameEngine.check_victory(result.new_state)
-	if victory["winner"] != 0:
+	var game_over: bool = victory["winner"] != 0 or result.new_state.phase == "finished"
+	if game_over:
 		result.new_state.phase = "finished"
 		result.new_state.winner_seat = victory["winner"]
 
@@ -326,7 +327,7 @@ func request_action(action_data: Dictionary) -> void:
 			result.new_state.to_dict()
 		)
 
-		if victory["winner"] != 0:
+		if game_over:
 			NetworkClient._send_game_ended.rpc_id(
 				p["peer_id"],
 				victory["winner"],

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -332,6 +332,29 @@ func _test_execute_volley_fire() -> void:
 		return result.success and result.new_state.units[1].panic_tokens == 1
 	)
 
+	_test("volley_fire: fizzle succeeds when no enemy in range", func():
+		var state = _mock_orders_state()
+		# u0 Toff weapon_range=6 at (10,30); u1 at (10,2) → distance 28, out of range.
+		# u3 at (12,2) → distance 26, also out of range. No valid target.
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
+		return (result.success
+			and result.new_state.units[0].has_ordered
+			and result.new_state.units[1].current_wounds == 0)
+	)
+
+	_test("volley_fire: fizzle rejected when a valid target exists", func():
+		var state = _mock_orders_state_ranged()
+		# Enemies are in range (18); fizzle should be refused.
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
+		return not result.success and "Cannot fizzle" in result.error
+	)
+
 	_test("volley_fire: multi-model unit fires one attack per model", func():
 		var state = _mock_orders_state_ranged()
 		# Make Fodder a 4-model ranged unit
@@ -517,6 +540,30 @@ func _test_execute_charge() -> void:
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 5, 1, 1])
 
 		return result.success and result.new_state.units[1].is_dead
+	)
+
+	_test("charge: fizzle succeeds when no enemy in charge range", func():
+		var state = _mock_orders_state()
+		# Default Toff M=6, blunder roll=1 caps bonus. Put enemies far away.
+		state.units[0].x = 10; state.units[0].y = 30
+		state.units[1].x = 10; state.units[1].y = 2   # distance 28
+		state.units[3].x = 12; state.units[3].y = 2   # distance 26
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
+		return (result.success and result.new_state.units[0].has_ordered)
+	)
+
+	_test("charge: fizzle rejected when a valid target exists", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10  # adjacent, clearly chargeable
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
+		return not result.success and "Cannot fizzle" in result.error
 	)
 
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -644,6 +644,43 @@ func _test_victory_conditions() -> void:
 		return victory["winner"] == 0 and victory["reason"] == ""
 	)
 
+	_test("Max-rounds tiebreak: more surviving units wins", func():
+		var state = _mock_orders_state()
+		state.current_round = 5
+		state.max_rounds = 4
+		# Kill one seat 2 non-snob unit so seat 1 has more alive
+		for unit in state.units:
+			if unit.owner_seat == 2 and not unit.is_snob():
+				unit.is_dead = true
+				break
+
+		var victory = GameEngine.check_victory(state)
+		return victory["winner"] == 1 and "Time expired" in victory["reason"]
+	)
+
+	_test("Max-rounds tiebreak: equal units, more models wins", func():
+		var state = _mock_orders_state()
+		state.current_round = 5
+		state.max_rounds = 4
+		# Both sides have same unit count alive; give seat 2 an extra model
+		for unit in state.units:
+			if unit.owner_seat == 2 and not unit.is_snob():
+				unit.model_count += 5
+				break
+
+		var victory = GameEngine.check_victory(state)
+		return victory["winner"] == 2 and "more models" in victory["reason"]
+	)
+
+	_test("Max-rounds tiebreak: fully tied = draw", func():
+		var state = _mock_orders_state()
+		state.current_round = 5
+		state.max_rounds = 4
+
+		var victory = GameEngine.check_victory(state)
+		return victory["winner"] == 0 and "Draw" in victory["reason"]
+	)
+
 
 # =============================================================================
 # MOCK STATE GENERATORS

--- a/memory/checkpoint-2026-04-20-victory-conditions.md
+++ b/memory/checkpoint-2026-04-20-victory-conditions.md
@@ -1,0 +1,54 @@
+# Checkpoint — 2026-04-20 — Victory conditions
+
+PR: [#35](https://github.com/rpmcdougall/turnipsim/pull/35) on branch `feature/victory-conditions`. **Awaiting merge.**
+
+## What shipped
+
+- **#22 victory conditions**
+  - `game_engine.gd:check_victory` extended with a max-rounds tiebreak (alive units → model count → draw) so games no longer hang after round 4.
+  - `network_server.request_action` now emits `_send_game_ended` whenever `phase == "finished"`, including the winner-0 draw case that the old code skipped.
+  - Client game-over overlay in `battle.gd:_show_game_over_overlay` — outcome title (green/red/yellow), reason, rounds played (clamped to `max_rounds`), surviving-unit counts per side, single **Return to Main Menu** button that disconnects and scene-changes.
+
+- **#33 stale lobby state** — surfaced during manual testing. `_disconnect_from_server` / `_on_server_disconnected` now call `_reset_army_state()` (clears `has_submitted_army`, `my_roster`, hides submit button, wipes army display). Without this, reconnecting to a different room left clients stuck ready-without-army.
+
+- **#34 order lock with no valid target** — also surfaced during testing.
+  - Engine: `_execute_volley_fire` and `_execute_charge` accept `params.fizzle == true`, guarded by new helpers `_has_valid_volley_target` / `_has_valid_charge_target` so fizzle is only legal when there genuinely are no targets.
+  - Log entries: `volley_fire_fizzled` / `charge_fizzled`.
+  - Client: `_render_order_execute_panel` detects the zero-target state and swaps instruction + shows "Continue (no effect)" button.
+  - `move_and_shoot` got a parallel fix — the Skip button is now always visible (labelled "Skip (no move, no shot)" before any destination is staged), since a blundered max_move=1 could otherwise trap the player with no clickable cell.
+
+- **CI lingering chore** — `.github/workflows/tests.yml` now runs `tests/test_game_engine.gd`. Previously only `test_runner.gd`, `test_ui_instantiate.gd`, and `test_phase3_scenes.gd` ran, so the 51-test engine suite was silently not gating on PRs.
+
+- **Wiki** — `docs/wiki/Manual-Testing-Guide.md` Victory section rewritten: end-condition table, per-path recipes (including the `max_rounds = 1` temp-edit trick for forcing max-rounds expiry), and overlay checklist.
+
+- **#36 filed** — the max-rounds tiebreak is a placeholder. v17 actually uses objective-based scoring (see change list: "p42. BUFF Snobs can capture Objectives"). The code branch is annotated with `TODO(objectives)` linking to #36.
+
+## Latent bugs found while testing
+
+1. **Zombie server on port 9999** — `test-stack.sh` didn't notice when an old server was still bound. The "new" stack's server silently failed with `Couldn't create an ENet host` while the clients connected to the old server, giving ghost-code behavior. Workaround: `taskkill //F //IM Godot_v4.6.2-stable_win64.exe` before relaunching. Worth teaching the script to detect/fail loudly — filed mentally, not yet in a ticket.
+
+2. **Grid visibility** — players can't tell which cells are valid movement destinations or which enemies are reachable without click-and-see. Added as a comment on #21 (Phase 5 polish); already in scope for that issue.
+
+## Test counts
+
+- `test_runner.gd`: 19 (unchanged)
+- `test_game_engine.gd`: 48 → **55** (3 tiebreak + 4 fizzle)
+
+## Commits on branch
+
+1. `bfcd857` engine: max-rounds tiebreak
+2. `9d7ebfe` client: game-over overlay + MEMORY.md fix
+3. `0df0eae` ci: run test_game_engine.gd
+4. `af97726` docs: wiki victory-testing procedures
+5. `11557aa` fix(lobby): clear roster state on disconnect (#33)
+6. `b82cc8f` fix(engine,ui): volley/charge fizzle (#34)
+7. `4646e88` fix(ui): move_and_shoot skip
+8. `ad82053` chore: TODO(objectives) marker for #36
+
+## What I'd do differently
+
+- The zombie-server class of bug cost ~20 min of confused debugging where server-log errors didn't match client behavior. The `test-stack.sh` script should refuse to start if port 9999 is already bound, or should `taskkill` stale Godot processes itself. Fast to add; worth doing before the next multi-iteration test session.
+
+## Next pickup
+
+Per user direction this session: **#28 roster builder** is up next (player-value high; current lobby picks a random preset on Select Army). After that, Phase 5 polish (#21) or Phase 6 deploy. #36 objectives is its own mini-phase before any serious rules-faithful play.


### PR DESCRIPTION
Closes #22. Also fixes #33 and #34 (surfaced during manual testing of this work — kept on-branch since they directly blocked verifying #22).

## Summary

- **#22 victory conditions** — max-rounds expiry now resolves (tiebreak by alive units → model count → draw) and emits `_send_game_ended` instead of freezing. New client-side game-over overlay shows outcome, reason, rounds played, surviving units per side, and a Return to Main Menu button.
- **#33 stale lobby state** — disconnecting no longer leaves `has_submitted_army` / `my_roster` set, so reconnecting to a different room shows the Submit button again.
- **#34 locked orders** — volley_fire / charge / move_and_shoot all now have a user-reachable Skip/Continue path when no valid target or destination exists (with server-side anti-cheat: fizzle refused if legal targets actually exist).

Deferred to #21 (Phase 5 polish): movement-range/attack-range visualisation on the board — noted in a comment on #21.

## Tests

- `test_game_engine.gd`: 48 → 55 (3 max-rounds tiebreak cases, 4 fizzle cases).
- CI: `test_game_engine.gd` wired into `.github/workflows/tests.yml` — it wasn't running before, which was a lingering chore.

## Commits

1. `bfcd857` engine: max-rounds tiebreak + emit game_ended on draw
2. `9d7ebfe` client: game-over overlay + MEMORY.md fix
3. `0df0eae` ci: run game engine tests
4. `af97726` docs: wiki victory-testing procedures
5. `11557aa` fix(lobby): clear roster state on disconnect (#33)
6. `b82cc8f` fix(engine,ui): volley/charge fizzle (#34)
7. `4646e88` fix(ui): move_and_shoot skip when no legal destination

## Test plan

- [x] 55/55 engine tests pass locally
- [x] Manual stack run — played through to the end-game overlay on max-rounds expiry
- [x] Manual stack run — Return to Main Menu button disconnects cleanly, main menu loads
- [x] Manual stack run — fizzle button appears when blundered charge / volley fire has no reachable enemy
- [x] Manual stack run — move_and_shoot Skip button appears even with max_move = 1 and no legal cell
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)