### PR TITLE
v17 objective scoring (#36)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,8 +1,8 @@
 # Turnip28 Simulator - Project Memory
 
 **Last Updated:** 2026-04-20
-**Current state:** Phase 5b roster builder complete. PR [#37](https://github.com/rpmcdougall/turnipsim/pull/37) **open on `feature/roster-builder`** awaiting merge. Closes #28. PR #35 already merged this day.
-**Active branch:** `feature/roster-builder` (pushed; don't start new work until merged)
+**Current state:** Phase 5 targeting-visibility polish shipped (PR #39, closes #21). PR #37 (roster builder, #28) and PR #35 (victory conditions) merged earlier this day. Issue #38 filed for pre-deploy v17 rules-accuracy audit (discovered StumpGun ammo types / Unstable Icon gaps mid-test).
+**Active branch:** `main` (clean — ready for next pickup)
 
 ## Phase status
 
@@ -16,10 +16,10 @@
 | 4 — Battle engine (initial) | ✅ | PR #26 — later replaced by v17 order state machine (PR #32) |
 | 4.5 — v17 data model | ✅ | PR #30 (issue #27) |
 | 4.5 — v17 order mechanics | ✅ | **PR #32 (issue #31)** — this session |
-| 5 — Polish | 🚧 | #22 ✅ (PR #35 merged), #21 Todo (visual polish — grid targeting visibility flagged on 2026-04-20), #36 Todo (objectives, replaces placeholder tiebreak) |
-| 5b — Army submission UI | 🚧 | **#28 on PR #37** — preset dropdown + custom slot builder with live validation, preset pre-fill, per-slot stats; in-room panel scroll-wrapped |
-| 6 — Deploy | ⬜ | #23–25 Todo |
-| 7 — Cult mechanics | ⬜ | #29 Todo |
+| 5 — Polish | 🚧 | #22 ✅ (PR #35), #21 ✅ (PR #39 — range diamonds + target rings during order_execute, immobile order hiding), #36 Todo (objectives, replaces placeholder tiebreak) |
+| 5b — Army submission UI | ✅ | PR #37 merged (#28) — preset dropdown + custom slot builder with live validation, preset pre-fill, per-slot stats |
+| 6 — Deploy | ⬜ | #23–25 Todo. **Gate:** #38 (v17 rules-accuracy audit) should precede deploy |
+| 7 — Cult mechanics | ⬜ | #29 Todo. #38's ammo-type plumbing will generalize into Grand Bombard (p.42) |
 
 ## Architecture quick-ref
 
@@ -124,10 +124,7 @@ Per-process logs land in `test-logs/` (gitignored). Ctrl+C tears everything down
 
 ## Next pickup
 
-Merge PR #37 first. Then, with #28 shipped:
-
-- **#21** — Phase 5 visual polish (grid targeting visibility flagged as friction on 2026-04-20, commented on issue). Most-obvious UX improvement for comfortable play-testing.
-- **#36** — v17 objectives (replaces the placeholder max-rounds tiebreak with real scoring). Self-contained mini-phase, rules-accuracy work.
-- **Phase 6** — export presets + deploy (#23–25).
-
-No dependencies between #21, #36, and Phase 6 — pick whichever fits the session.
+- **#36** — v17 objectives (replaces placeholder max-rounds tiebreak with real scoring). Self-contained, natural rules-accuracy warmup before #38.
+- **#38** — full v17 rules-accuracy audit (StumpGun ammo types, Unstable Icon, Preliminary Bombardment, per-unit specials). Gate before deploy. See `memory/rules_accuracy_gaps.md` for seed list.
+- **Phase 6** — export presets + deploy (#23–25). Do #38 first.
+- Remaining #21 scope (sprites, particles, tooltips, camera pan/zoom, placement-undo) — deferred; PR #39 only shipped the three items flagged in the issue comment.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -18,7 +18,7 @@
 | 4.5 — v17 order mechanics | ✅ | **PR #32 (issue #31)** — this session |
 | 5 — Polish | 🚧 | #22 ✅ (PR #35), #21 ✅ (PR #39 — range diamonds + target rings during order_execute, immobile order hiding), #36 Todo (objectives, replaces placeholder tiebreak) |
 | 5b — Army submission UI | ✅ | PR #37 merged (#28) — preset dropdown + custom slot builder with live validation, preset pre-fill, per-slot stats |
-| 6 — Deploy | ⬜ | #23–25 Todo. **Gate:** #38 (v17 rules-accuracy audit) should precede deploy |
+| 6 — Deploy | ⬜ | #23–25 Todo. **Gates:** #38 (rules-accuracy audit) + #40 (simultaneous return fire + retreat) should precede deploy |
 | 7 — Cult mechanics | ⬜ | #29 Todo. #38's ammo-type plumbing will generalize into Grand Bombard (p.42) |
 
 ## Architecture quick-ref

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -356,10 +356,24 @@ func _render_state() -> void:
 	_reconcile_selection_state()
 
 	var is_my_turn = current_game_state.active_seat == my_seat
-	turn_banner.text = "Round %d — Player %d %s" % [
+	var turn_suffix := "(Your turn)"
+	if not is_my_turn:
+		turn_suffix = "(Opponent's turn)"
+	var objs_1: int = 0
+	var objs_2: int = 0
+	for obj in current_game_state.objectives:
+		if obj.captured_by == 1:
+			objs_1 += 1
+		elif obj.captured_by == 2:
+			objs_2 += 1
+	var objective_tag := ""
+	if current_game_state.objectives.size() > 0:
+		objective_tag = "   |   Objectives P1: %d · P2: %d" % [objs_1, objs_2]
+	turn_banner.text = "Round %d — Player %d %s%s" % [
 		current_game_state.current_round,
 		current_game_state.active_seat,
-		"(Your turn)" if is_my_turn else "(Opponent's turn)"
+		turn_suffix,
+		objective_tag
 	]
 
 	# Hide all order-phase panels first

--- a/godot/client/scenes/grid_draw.gd
+++ b/godot/client/scenes/grid_draw.gd
@@ -44,9 +44,16 @@ func _draw() -> void:
 		draw_string(font, Vector2(4, battle_ref.DEPLOY_2_Y_MAX * cs + cs * 0.8), "P2 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(1, 0.6, 0.6, 0.6))
 		draw_string(font, Vector2(4, battle_ref.DEPLOY_1_Y_MIN * cs + cs * 0.8), "P1 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0.6, 0.6, 1.0, 0.6))
 
-	# Command-range overlay: Manhattan diamond around the Made-Ready Snob.
-	# Matches the engine's |dx| + |dy| <= range check used by declare_order.
 	var state = battle_ref.current_game_state
+
+	# Objective markers. Drawn before command/reach overlays so they show
+	# through tints, but before unit sprites (handled in battle.gd's
+	# units_container) so units on adjacent cells still read clearly.
+	if state:
+		for obj in state.objectives:
+			_draw_objective_marker(obj, cs)
+
+	# Command-range overlay: Manhattan diamond around the Made-Ready Snob.
 	if state and state.order_phase == "order_declare" and state.current_snob_id != "":
 		var snob = battle_ref._get_unit_by_id(state.current_snob_id)
 		if snob and snob.x >= 0 and snob.y >= 0:
@@ -57,6 +64,33 @@ func _draw() -> void:
 	# acting unit. Client-side hint only — server remains authoritative.
 	if state and state.order_phase == "order_execute":
 		_draw_order_execute_overlay(state, cs, bw, bh)
+
+
+## Draw an objective marker: filled circle in the cell's center, colored by
+## the controlling seat (neutral grey when uncaptured), with a darker outline
+## for contrast against both board and highlight overlays.
+func _draw_objective_marker(obj, cs: float) -> void:
+	var fill: Color
+	var outline: Color
+	match obj.captured_by:
+		1:
+			fill = Color(0.35, 0.6, 1.0, 0.95)
+			outline = Color(0.15, 0.3, 0.6, 1.0)
+		2:
+			fill = Color(1.0, 0.4, 0.4, 0.95)
+			outline = Color(0.6, 0.15, 0.15, 1.0)
+		_:
+			fill = Color(0.85, 0.85, 0.85, 0.9)
+			outline = Color(0.3, 0.3, 0.3, 1.0)
+
+	var center = Vector2((obj.x + 0.5) * cs, (obj.y + 0.5) * cs)
+	var radius = cs * 0.38
+	draw_circle(center, radius, fill)
+	draw_arc(center, radius, 0.0, TAU, 32, outline, 2.0, true)
+
+	# Center dot emphasizes captured state without leaning on text rendering.
+	if obj.captured_by != 0:
+		draw_circle(center, radius * 0.35, outline)
 
 
 ## Fill every cell whose Manhattan distance from (cx, cy) is ≤ range with a

--- a/godot/game/types.gd
+++ b/godot/game/types.gd
@@ -347,6 +347,33 @@ class UnitState extends RefCounted:
 		return 0
 
 
+## Scenario objective marker. Placed before deployment, immobile for the
+## game, captured/uncaptured by Follower units per v17 core rules p.22.
+## captured_by: 0 = uncaptured, 1 or 2 = seat that controls it.
+class Objective extends RefCounted:
+	var id: String = ""
+	var x: int = 0
+	var y: int = 0
+	var captured_by: int = 0
+
+	func _init(p_id: String = "", p_x: int = 0, p_y: int = 0, p_captured_by: int = 0) -> void:
+		id = p_id
+		x = p_x
+		y = p_y
+		captured_by = p_captured_by
+
+	func to_dict() -> Dictionary:
+		return {"id": id, "x": x, "y": y, "captured_by": captured_by}
+
+	static func from_dict(data: Dictionary) -> Objective:
+		return Objective.new(
+			data.get("id", ""),
+			data.get("x", 0),
+			data.get("y", 0),
+			data.get("captured_by", 0)
+		)
+
+
 ## Game state for a battle in progress.
 class GameState extends RefCounted:
 	var room_code: String = ""
@@ -356,6 +383,7 @@ class GameState extends RefCounted:
 	var active_seat: int = 1
 	var initiative_seat: int = 1    # Player with initiative (set once, stays)
 	var units: Array[UnitState] = []
+	var objectives: Array[Objective] = []
 	var action_log: Array[Dictionary] = []
 	var winner_seat: int = 0
 
@@ -393,6 +421,10 @@ class GameState extends RefCounted:
 		for unit in units:
 			units_array.append(unit.to_dict())
 
+		var objectives_array: Array = []
+		for obj in objectives:
+			objectives_array.append(obj.to_dict())
+
 		return {
 			"room_code": room_code,
 			"phase": phase,
@@ -401,6 +433,7 @@ class GameState extends RefCounted:
 			"active_seat": active_seat,
 			"initiative_seat": initiative_seat,
 			"units": units_array,
+			"objectives": objectives_array,
 			"action_log": action_log,
 			"winner_seat": winner_seat,
 			"order_phase": order_phase,
@@ -438,6 +471,12 @@ class GameState extends RefCounted:
 		gs.current_order_type = data.get("current_order_type", "")
 		gs.current_order_blundered = data.get("current_order_blundered", false)
 		gs.current_order_move_bonus = data.get("current_order_move_bonus", 0)
+
+		if data.has("objectives"):
+			var objs: Array[Objective] = []
+			for obj_data in data["objectives"]:
+				objs.append(Objective.from_dict(obj_data))
+			gs.objectives = objs
 		return gs
 
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -130,6 +130,9 @@ static func confirm_placement(state: Types.GameState) -> Types.EngineResult:
 		new_state.phase = "orders"
 		new_state.order_phase = "snob_select"
 		new_state.active_seat = new_state.initiative_seat
+		# v17 p.22: "Objectives with units deployed within 1" are considered
+		# captured." Run the resolver once deployment is final.
+		_resolve_objective_captures(new_state)
 		new_state.action_log.append({
 			"round": state.current_round,
 			"action": "orders_phase_started"
@@ -752,6 +755,9 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 ## After an order is fully executed, advance the state machine.
 ## Marks units as ordered, switches players, transitions phases.
 static func _advance_after_order(state: Types.GameState) -> void:
+	# Re-resolve objective control after any positional or unit-death change.
+	_resolve_objective_captures(state)
+
 	# Mark the ordered unit
 	var unit = _find_unit_in(state, state.current_order_unit_id)
 	if unit:
@@ -951,29 +957,23 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 	if snobs_alive_2 == 0 and snobs_alive_1 > 0:
 		return {"winner": 1, "reason": "Player 2 lost all Snobs (Headless Chicken)"}
 
-	# Time limit reached: placeholder tiebreak by surviving units, then by
-	# model count. v17's real rule is objective-based scoring (see #36) —
-	# replace this branch once objectives / scenarios are implemented.
-	# TODO(objectives): see https://github.com/rpmcdougall/turnipsim/issues/36
+	# Round limit reached: v17 objective scoring (core p.22, scenarios p.23+).
+	# "The player who controls the most objective markers at the end of the
+	# final round is the victor." Ties go straight to draw — no secondary
+	# model-count fallback in the rules.
 	if state.current_round > state.max_rounds:
-		if units_alive_1 > units_alive_2:
-			return {"winner": 1, "reason": "Time expired — Player 1 holds the field"}
-		if units_alive_2 > units_alive_1:
-			return {"winner": 2, "reason": "Time expired — Player 2 holds the field"}
-		var models_alive_1: int = 0
-		var models_alive_2: int = 0
-		for unit in state.units:
-			if unit.is_dead:
-				continue
-			if unit.owner_seat == 1:
-				models_alive_1 += unit.model_count
-			else:
-				models_alive_2 += unit.model_count
-		if models_alive_1 > models_alive_2:
-			return {"winner": 1, "reason": "Time expired — Player 1 has more models standing"}
-		if models_alive_2 > models_alive_1:
-			return {"winner": 2, "reason": "Time expired — Player 2 has more models standing"}
-		return {"winner": 0, "reason": "Time expired — the field is contested (Draw)"}
+		var objectives_1: int = 0
+		var objectives_2: int = 0
+		for obj in state.objectives:
+			if obj.captured_by == 1:
+				objectives_1 += 1
+			elif obj.captured_by == 2:
+				objectives_2 += 1
+		if objectives_1 > objectives_2:
+			return {"winner": 1, "reason": "Player 1 controls %d objective(s) to %d" % [objectives_1, objectives_2]}
+		if objectives_2 > objectives_1:
+			return {"winner": 2, "reason": "Player 2 controls %d objective(s) to %d" % [objectives_2, objectives_1]}
+		return {"winner": 0, "reason": "Objectives tied %d–%d (Draw)" % [objectives_1, objectives_2]}
 
 	return {"winner": 0, "reason": ""}
 
@@ -1086,7 +1086,60 @@ static func _validate_move(state: Types.GameState, unit: Types.UnitState, x: int
 	for u in state.units:
 		if not u.is_dead and u.x == x and u.y == y and u.id != unit.id:
 			return "Position occupied"
+	# v17 core p.22: "A unit may move across objectives, but may never finish
+	# a move on top of one."
+	if _is_objective_at(state, x, y):
+		return "Cannot end move on an objective marker"
 	return ""
+
+
+## Is there an objective marker at this cell?
+static func _is_objective_at(state: Types.GameState, x: int, y: int) -> bool:
+	for obj in state.objectives:
+		if obj.x == x and obj.y == y:
+			return true
+	return false
+
+
+## Recompute capture state for every objective per v17 core p.22.
+## Called after any state change that could shift Follower positions
+## (placement finalized, moves, charges, unit deaths). Mutates in place.
+##
+## Rules modeled:
+##   - Only Follower units capture (Snobs never do).
+##   - "Within 1"" maps to Manhattan distance == 1 (orthogonal neighbor).
+##   - Objective cell itself is uncapturable-from; units can't end there.
+##   - If only one seat has adjacent Followers → captured by that seat.
+##   - If both seats have adjacent Followers → contested (uncaptured).
+##   - If neither seat has adjacent Followers → retain previous control.
+##
+## MVP simplification: the v17 "only one objective captured per move"
+## player-choice rule is not enforced here — a move that ends adjacent to
+## two uncontrolled objectives will capture both. Tracked for a follow-up
+## when objective placement is dense enough to matter in practice.
+static func _resolve_objective_captures(state: Types.GameState) -> void:
+	for obj in state.objectives:
+		var seat1_adjacent := 0
+		var seat2_adjacent := 0
+		for u in state.units:
+			if u.is_dead or u.is_snob():
+				continue
+			if u.x < 0 or u.y < 0:
+				continue
+			var d: int = abs(u.x - obj.x) + abs(u.y - obj.y)
+			if d == 1:
+				if u.owner_seat == 1:
+					seat1_adjacent += 1
+				else:
+					seat2_adjacent += 1
+		if seat1_adjacent > 0 and seat2_adjacent > 0:
+			obj.captured_by = 0
+		elif seat1_adjacent > 0:
+			obj.captured_by = 1
+		elif seat2_adjacent > 0:
+			obj.captured_by = 2
+		# else: retain obj.captured_by (captured objective stays captured
+		# until enemy contests or claims it).
 
 
 ## Find the best adjacent cell to a target for a charging unit.
@@ -1106,6 +1159,9 @@ static func _find_adjacent_cell(state: Types.GameState, charger: Types.UnitState
 				occupied = true
 				break
 		if occupied:
+			continue
+		# Objective cells are invalid end-of-move destinations (v17 p.22).
+		if _is_objective_at(state, cx, cy):
 			continue
 		var dist = abs(cx - charger.x) + abs(cy - charger.y)
 		if dist < best_dist:

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -470,6 +470,23 @@ func _initialize_game_state(room) -> Dictionary:
 					"snob_id": snob_id
 				})
 
+	# Objective placement. v17 core p.22: "Every scenario will present the
+	# players with up to 5 objectives and instructions on how to place them."
+	# Real scenarios drive count + layout + placement rules (players taking
+	# turns to place). Until the scenario system lands (see memory note on
+	# scenarios_future_design), we auto-place 5 markers evenly along the
+	# centerline as a stand-in.
+	var objectives: Array = []
+	var centerline_y := 16  # Board is 48x32 (see battle.gd); midpoint.
+	var xs := [8, 16, 24, 32, 40]
+	for i in range(xs.size()):
+		objectives.append({
+			"id": "obj_%d" % i,
+			"x": xs[i],
+			"y": centerline_y,
+			"captured_by": 0
+		})
+
 	return {
 		"room_code": room.code,
 		"phase": "placement",
@@ -478,6 +495,7 @@ func _initialize_game_state(room) -> Dictionary:
 		"active_seat": initiative_seat,
 		"initiative_seat": initiative_seat,
 		"units": units,
+		"objectives": objectives,
 		"action_log": [],
 		"winner_seat": 0
 	}

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -22,6 +22,7 @@ func _init() -> void:
 	_test_execute_charge()
 	_test_advance_flow()
 	_test_victory_conditions()
+	_test_objectives()
 
 	print("")
 	print("============================================================")
@@ -691,41 +692,106 @@ func _test_victory_conditions() -> void:
 		return victory["winner"] == 0 and victory["reason"] == ""
 	)
 
-	_test("Max-rounds tiebreak: more surviving units wins", func():
+	_test("Round-limit: seat with more captured objectives wins", func():
 		var state = _mock_orders_state()
 		state.current_round = 5
 		state.max_rounds = 4
-		# Kill one seat 2 non-snob unit so seat 1 has more alive
-		for unit in state.units:
-			if unit.owner_seat == 2 and not unit.is_snob():
-				unit.is_dead = true
-				break
+		state.objectives = _mock_objectives([[1, 2], [1, 0], [2, 0]])
 
 		var victory = GameEngine.check_victory(state)
-		return victory["winner"] == 1 and "Time expired" in victory["reason"]
+		return victory["winner"] == 1 and "2 objective" in victory["reason"]
 	)
 
-	_test("Max-rounds tiebreak: equal units, more models wins", func():
+	_test("Round-limit: equal objective counts = draw (no model tiebreak)", func():
 		var state = _mock_orders_state()
 		state.current_round = 5
 		state.max_rounds = 4
-		# Both sides have same unit count alive; give seat 2 an extra model
+		# Equal objective counts; seat 2 has extra models → still a draw per v17.
+		state.objectives = _mock_objectives([[1, 0], [2, 0]])
 		for unit in state.units:
 			if unit.owner_seat == 2 and not unit.is_snob():
 				unit.model_count += 5
 				break
 
 		var victory = GameEngine.check_victory(state)
-		return victory["winner"] == 2 and "more models" in victory["reason"]
+		return victory["winner"] == 0 and "Draw" in victory["reason"]
 	)
 
-	_test("Max-rounds tiebreak: fully tied = draw", func():
+	_test("Round-limit: no captured objectives = 0–0 draw", func():
 		var state = _mock_orders_state()
 		state.current_round = 5
 		state.max_rounds = 4
+		state.objectives = _mock_objectives([[0, 0], [0, 0]])
 
 		var victory = GameEngine.check_victory(state)
 		return victory["winner"] == 0 and "Draw" in victory["reason"]
+	)
+
+
+# =============================================================================
+# OBJECTIVE CAPTURE / BLOCKING
+# =============================================================================
+
+func _test_objectives() -> void:
+	print("")
+	print("[Test Suite: Objectives]")
+
+	_test("Follower adjacent to uncaptured objective captures it", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[20, 15]])
+		state.units[2].x = 20; state.units[2].y = 16  # seat 1 Follower
+		GameEngine._resolve_objective_captures(state)
+		return state.objectives[0].captured_by == 1
+	)
+
+	_test("Snob adjacent to objective does NOT capture", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[10, 29]])
+		# Seat 1 Snob at (10, 30) is already adjacent to (10, 29).
+		GameEngine._resolve_objective_captures(state)
+		return state.objectives[0].captured_by == 0
+	)
+
+	_test("Contested objective (both seats adjacent) becomes uncaptured", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[15, 15]])
+		state.objectives[0].captured_by = 1  # Pre-existing control
+		state.units[2].x = 15; state.units[2].y = 14  # seat 1 Follower
+		state.units[3].x = 15; state.units[3].y = 16  # seat 2 Follower
+		GameEngine._resolve_objective_captures(state)
+		return state.objectives[0].captured_by == 0
+	)
+
+	_test("Captured objective stays captured when the Follower leaves", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[20, 15]])
+		state.objectives[0].captured_by = 2
+		# No followers adjacent at all.
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 0; state.units[3].y = 31
+		GameEngine._resolve_objective_captures(state)
+		return state.objectives[0].captured_by == 2
+	)
+
+	_test("Enemy Follower entering a controlled objective flips capture", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[20, 15]])
+		state.objectives[0].captured_by = 1
+		# Seat 2 Follower adjacent, seat 1 Follower far away.
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 20; state.units[3].y = 14
+		GameEngine._resolve_objective_captures(state)
+		return state.objectives[0].captured_by == 2
+	)
+
+	_test("March onto an objective cell is rejected", func():
+		var state = _mock_orders_state()
+		state.objectives = _mock_objectives_at([[20, 15]])
+		var follower = state.units[2]
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, follower.id, "march", 4, [3, 3]).new_state
+		var res = GameEngine.execute_order(state, {"x": 20, "y": 15}, [])
+		return not res.success and "objective" in res.error
 	)
 
 
@@ -737,6 +803,26 @@ func _mock_unit(id: String, seat: int, unit_type: String, category: String, m: i
 	var stats = Types.Stats.new(m, a, i, w, v, wr)
 	var rules: Array[String] = []
 	return Types.UnitState.new(id, seat, unit_type, category, models, models, stats, "black_powder", rules)
+
+
+## Build an objectives list from [captured_by, placeholder] pairs. The second
+## element is unused — tests only care about captured_by — but the shape
+## keeps each entry visually distinct. Positions are synthetic (i*3, 10).
+func _mock_objectives(entries: Array) -> Array[Types.Objective]:
+	var out: Array[Types.Objective] = []
+	for i in range(entries.size()):
+		var entry = entries[i]
+		out.append(Types.Objective.new("obj_%d" % i, i * 3, 10, entry[0]))
+	return out
+
+
+## Objectives placed at explicit [x, y] coords, all starting uncaptured.
+func _mock_objectives_at(positions: Array) -> Array[Types.Objective]:
+	var out: Array[Types.Objective] = []
+	for i in range(positions.size()):
+		var p = positions[i]
+		out.append(Types.Objective.new("obj_%d" % i, p[0], p[1], 0))
+	return out
 
 
 func _mock_game_state() -> Types.GameState:


### PR DESCRIPTION
Closes #36. Replaces the placeholder max-rounds tiebreak (alive units → model count → draw) with the real v17 victory rule: most captured objectives at the end of the final round wins; tied counts are an explicit draw with no secondary fallback (rules, core p.22 and scenarios pp.23–25).

## Summary

### Engine
- \`Objective\` class + \`GameState.objectives\` plumbing with to_dict/from_dict, so \`_clone_state\` picks them up automatically.
- \`_resolve_objective_captures\`: Follower-only capture (Snobs never capture), \"within 1\"\" mapped to Manhattan ≤ 1, contested markers become uncaptured, captured markers are retained when their Follower leaves — called from \`_advance_after_order\` and at placement→orders so any positional or unit-death change re-resolves control.
- \`_validate_move\` rejects end-cells on an objective; \`_find_adjacent_cell\` (charge destination search) skips objective cells. Covers \"may never finish a move on top of one.\"
- \`check_victory\`'s max-rounds branch rewritten to objective-count scoring.

### Placement (stopgap)
- \`network_server._initialize_game_state\` drops 5 markers evenly along the centerline (x = 8, 16, 24, 32, 40 at y = 16).
- Real scenario-driven placement is deferred. When scenarios are picked up, the design target is a JSON schema + PDF parse pipeline (see session memory). The hardcoded layout is explicitly a stopgap.

### Client
- \`grid_draw\` paints each objective as a filled circle, colored by \`captured_by\` (blue for seat 1, red for seat 2, neutral grey when uncaptured). A darker center dot appears when controlled so the marker reads at a glance.
- Turn banner appends per-seat objective totals whenever the state has any objectives: \`Objectives P1: 2 · P2: 1\`.

## Known MVP deviation

v17's \"only one objective captured per move\" player-choice rule is not enforced — a move ending adjacent to two uncontrolled markers currently captures both. With centerline placement this is extremely rare (markers are 8 cells apart). Documented in code for a follow-up if it becomes a practical issue.

## Out of scope (filed for follow-up)

Two combat-engagement mechanics observed during manual testing are gaps but unrelated to this issue:
- Return fire and retreat — filed as #40, tracked alongside #38 as a Phase 6 deploy gate.
- Powder smoke visual indicator — piggybacks on #40.

## Test plan
- [x] \`test_runner.gd\` (19 tests)
- [x] \`test_game_engine.gd\` (61 tests — 6 new objective-suite tests, 3 rewritten victory tests)
- [x] Local stack: confirmed markers render, capture flips on Follower adjacency, and score updates in the banner
- [x] Confirmed Snobs do not capture (adjacency without a Follower leaves the marker neutral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)