### PR TITLE
v17 data corrections + initiative roll-off (#38)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,8 +1,8 @@
 # Turnip28 Simulator - Project Memory
 
 **Last Updated:** 2026-04-20
-**Current state:** Phase 5 targeting-visibility polish shipped (PR #39, closes #21). PR #37 (roster builder, #28) and PR #35 (victory conditions) merged earlier this day. Issue #38 filed for pre-deploy v17 rules-accuracy audit (discovered StumpGun ammo types / Unstable Icon gaps mid-test).
-**Active branch:** `main` (clean — ready for next pickup)
+**Current state:** v17 rules-accuracy audit (#38) complete; PR [#43](https://github.com/rpmcdougall/turnipsim/pull/43) in flight with the first data-correction slice. 16 sub-issues filed (#44–#59) covering all audit gaps, all on the project board. PR #41 (objectives, closes #36), PR #39 (targeting, closes #21), PR #37 (roster builder, closes #28), PR #35 (victory conditions) all merged.
+**Active branch:** `feature/rules-audit-v17` (PR #43 open awaiting merge)
 
 ## Phase status
 
@@ -16,10 +16,11 @@
 | 4 — Battle engine (initial) | ✅ | PR #26 — later replaced by v17 order state machine (PR #32) |
 | 4.5 — v17 data model | ✅ | PR #30 (issue #27) |
 | 4.5 — v17 order mechanics | ✅ | **PR #32 (issue #31)** — this session |
-| 5 — Polish | 🚧 | #22 ✅ (PR #35), #21 ✅ (PR #39 — range diamonds + target rings during order_execute, immobile order hiding), #36 Todo (objectives, replaces placeholder tiebreak) |
+| 5 — Polish | ✅ (scoped) | #22 ✅ (PR #35), #21 ✅ (PR #39 — flagged bullets only; sprites/camera/tooltips deferred), #36 ✅ (PR #41 — v17 objective scoring) |
 | 5b — Army submission UI | ✅ | PR #37 merged (#28) — preset dropdown + custom slot builder with live validation, preset pre-fill, per-slot stats |
-| 6 — Deploy | ⬜ | #23–25 Todo. **Gates:** #38 (rules-accuracy audit) + #40 (simultaneous return fire + retreat) should precede deploy |
-| 7 — Cult mechanics | ⬜ | #29 Todo. #38's ammo-type plumbing will generalize into Grand Bombard (p.42) |
+| 5.5 — Rules-accuracy pass | 🚧 | #38 umbrella; PR #43 in flight. 16 sub-issues (#44–#59) cover all audit gaps. See `memory/checkpoint-2026-04-20-rules-audit.md` for catalog. |
+| 6 — Deploy | ⬜ | #23–25 Todo. **Gates:** #38 audit + #40 (return fire + retreat) + #42 (Cult audit) before deploy |
+| 7 — Cult mechanics | ⬜ | #29 Todo. #38's ammo-type plumbing will generalize into Grand Bombard (p.42). Validated against rules via #42. |
 
 ## Architecture quick-ref
 
@@ -120,11 +121,20 @@ Per-process logs land in `test-logs/` (gitignored). Ctrl+C tears everything down
 - `memory/checkpoint-2026-04-18-phase-4-ui.md`
 - `memory/checkpoint-2026-04-19-order-mechanics.md`
 - `memory/checkpoint-2026-04-20-victory-conditions.md`
-- `memory/checkpoint-2026-04-20-roster-builder.md` ← this session
+- `memory/checkpoint-2026-04-20-roster-builder.md`
+- `memory/checkpoint-2026-04-20-rules-audit.md` ← this session
 
 ## Next pickup
 
-- **#36** — v17 objectives (replaces placeholder max-rounds tiebreak with real scoring). Self-contained, natural rules-accuracy warmup before #38.
-- **#38** — full v17 rules-accuracy audit (StumpGun ammo types, Unstable Icon, Preliminary Bombardment, per-unit specials). Gate before deploy. See `memory/rules_accuracy_gaps.md` for seed list.
-- **Phase 6** — export presets + deploy (#23–25). Do #38 first.
-- Remaining #21 scope (sprites, particles, tooltips, camera pan/zoom, placement-undo) — deferred; PR #39 only shipped the three items flagged in the issue comment.
+Primary track = rules-accuracy (#38) sub-issues. Suggested order:
+1. **#44** — grid-vs-inches decision. Meta, gates LoS / 1" rule / range math. Small discussion + decision-log entry in CLAUDE.md.
+2. **#52** — panic test subsystem. Foundational; unlocks charge panic, retreat, Fearless, Safety in Numbers, Bowel-Loosening.
+3. **#53** — retreat subsystem. Depends on #52.
+4. **#55** — two-sided melee bouts. Depends on #52 / #53.
+5. **#56** — LoS + closest-target. Depends on #44.
+6. Independent mediums interleaved: #45 (Improbable Hits), #46 (1" rule), #47 (charge fixes), #48 (snob-moves-with-unit), #49 (reroll infra), #50 (Vanguard), #51 (Dash), #54 (Stand and Shoot), #57 (Toff Off).
+7. **#58** terrain, **#59** scenarios — systems-sized, coordinate with scenario data memory.
+8. **#42** — Cult rules audit. Last pre-deploy gate.
+9. Phase 6 (#23–25) — after #38 and #40 and #42.
+
+Deferred #21 bullets (sprites, camera, tooltips, placement-undo) — not blocking anything; revisit post-deploy.

--- a/godot/game/rulesets/v17.json
+++ b/godot/game/rulesets/v17.json
@@ -138,9 +138,9 @@
         "vulnerability": 6,
         "weapon_range": 18
       },
-      "special_rules": ["sharpshooters", "skirmish"],
+      "special_rules": ["sharpshooters", "skirmish", "vanguard"],
       "allowed_equipment": ["black_powder", "missile", "close_combat"],
-      "description": "Light skirmishers. Can target any enemy. Hard to hit with shooting (+2 I for shooters)."
+      "description": "Light skirmishers. Can target any enemy. Hard to hit with shooting (+2 I for shooters). Deploy forward with Vanguard."
     },
     "Brutes": {
       "unit_type": "Brutes",
@@ -154,9 +154,9 @@
         "vulnerability": 5,
         "weapon_range": 18
       },
-      "special_rules": ["fearless", "vanguard"],
+      "special_rules": ["fearless"],
       "allowed_equipment": ["black_powder", "missile", "close_combat"],
-      "description": "Dedicated fanatics. Fearless (3+ to ignore retreat). Deploy forward with Vanguard."
+      "description": "Dedicated fanatics. Fearless (3+ to ignore retreat)."
     },
     "Whelps": {
       "unit_type": "Whelps",
@@ -200,11 +200,11 @@
         "inaccuracy": 6,
         "wounds": 3,
         "vulnerability": 5,
-        "weapon_range": 48
+        "weapon_range": 60
       },
       "special_rules": ["immobile", "unstable_icon", "stubborn_fanatics", "preliminary_bombardment"],
       "allowed_equipment": ["black_powder"],
-      "description": "Ancient cannon. Immobile. Round Shot (48\", 3 wounds no save) or Grape Shot (12\", 5 dice)."
+      "description": "Ancient cannon. Immobile. Round Shot (60\", 2 wounds per hit, no save) or Grape Shot (12\", 3D6 attacks). Ammo split pending — see issue #38."
     }
   },
 

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -389,8 +389,19 @@ func _initialize_game_state(room) -> Dictionary:
 	var ruleset = Ruleset.new()
 	ruleset.load_from_file("res://game/rulesets/v17.json")
 
-	# Roll initiative — seat 1 or 2
-	var initiative_seat = 1 if _roll_d6() <= 3 else 2
+	# Roll initiative — v17 core p.9: players roll off with a D6 each; ties
+	# re-roll. Higher roll takes initiative.
+	var initiative_seat: int = 1
+	while true:
+		var roll_1 := _roll_d6()
+		var roll_2 := _roll_d6()
+		if roll_1 > roll_2:
+			initiative_seat = 1
+			break
+		elif roll_2 > roll_1:
+			initiative_seat = 2
+			break
+		# Tie — re-roll.
 
 	# Expand each player's roster into UnitStates
 	for player in room.players:

--- a/memory/checkpoint-2026-04-20-rules-audit.md
+++ b/memory/checkpoint-2026-04-20-rules-audit.md
@@ -1,0 +1,80 @@
+# Checkpoint — 2026-04-20 — v17 rules audit (Phase 6 prep)
+
+**PRs shipped this day (prior to this session):** #35 (victory conditions), #37 (roster builder), #39 (targeting visibility), #41 (objective scoring).
+
+**This session's scope:** full v17 core-rules accuracy audit (#38), fix the small data divergences inline, and file sub-issues for every remaining gap so the audit finding catalog is tracker-visible.
+
+## Work shipped
+
+- **PR [#43](https://github.com/rpmcdougall/turnipsim/pull/43)** — first slice of #38. Five inline data corrections:
+  - Chaff gains `vanguard` (JSON was missing it per v17 p.31).
+  - Brutes loses `vanguard` (JSON had it incorrectly; book p.30 says no).
+  - Stump Gun `weapon_range` 48 → 60 (Round Shot is 60" per p.32).
+  - Stump Gun description corrected: 2 wounds per Round Shot hit (not 3); notes the 3D6 Grape Shot attack count.
+  - Initiative roll replaced with proper roll-off: two D6, higher wins, ties re-roll (p.9).
+
+## Audit findings + sub-issues filed
+
+Audit delegated to a research agent with `/tmp/v17.txt` (pdftotext of the v17 core rules). Produced a structured catalog with finding IDs, severity, fix-size, file:line hotspots, and a recommended PR split. Counts: 8 critical, 14 major, 9 minor, 16 implemented-correctly.
+
+**Orphans added to board during this session:** #38 (core audit umbrella), #40 (return fire + retreat), #42 (Cult audit — pre-deploy, not tackled yet).
+
+**Sub-issues filed (all on project board, Todo):**
+
+| # | Title | Severity | Fix size |
+|---|---|---|---|
+| #44 | Decision: inches vs. integer-Manhattan grid | Critical | Large (meta) |
+| #45 | Improbable Hits (7+/8+) | Critical | Medium |
+| #46 | 1" rule for non-charge moves | Major | Small |
+| #47 | Charge fail-still-move-full + 1" exception | Major | Small |
+| #48 | Snob moves with commanded unit | Minor | Small |
+| #49 | Reroll infrastructure | Major | Medium |
+| #50 | Vanguard pre-game phase | Major | Medium |
+| #51 | Dash free move after Whelps' order | Major | Small |
+| #52 | Panic test subsystem (foundational) | Critical | Medium |
+| #53 | Retreat subsystem | Critical | Large |
+| #54 | Stand and Shoot | Critical | Medium |
+| #55 | Two-sided melee bouts + post-melee panic | Critical | Large |
+| #56 | LoS + closest-target enforcement | Critical | Large |
+| #57 | Toff Off duel | Major | — |
+| #58 | Terrain system | Major | Large |
+| #59 | Scenario system | Major | Large |
+
+Plus the cult-audit umbrella (#42) still outstanding as a Phase 6 gate.
+
+## Sequencing decision
+
+Agreed plan with user: modular discrete chunks.
+
+1. **#43 data PR** (this session — shipping now)
+2. **#44 grid-vs-inches decision** — meta, gates LoS / 1" rule / range math
+3. **#52 panic subsystem** — foundational; unlocks charge panic, retreat, Fearless, Bowel-Loosening
+4. **#53 retreat subsystem** — depends on panic
+5. **#55 two-sided melee bouts** — depends on panic/retreat
+6. **#56 LoS + closest-target** — depends on grid decision
+7. Independent mediums (#45 / #46 / #47 / #48 / #49 / #50 / #51 / #54 / #57)
+8. Systems-sized (#58 terrain, #59 scenarios) — coupled with scenarios memory
+9. #42 Cult audit — last, pre-deploy
+
+## Notable insights from the audit
+
+- Order sequence, equipment, roster validation, objectives, victory check are **solid**. The rules engine isn't wrong — it's *incomplete*. Good news.
+- **None of the special rules in `v17.json` beyond `immobile` are actually enforced.** They're data waiting for engine support.
+- **Panic tests are the keystone** — once they land, Fearless / Safety in Numbers / Bowel-Loosening / Stubborn Fanatics / retreat-on-loss / charge-panic-test all become wirings, not new features.
+- **Grid-vs-inches decision ripples through every range check.** Worth a decision-log pass before committing to more combat mechanics.
+- Change list (`rules_export/Change list v17.txt`) cross-checked during session — it's the v16→v17 delta and confirms data points we now have right (Bastards 2W, Whelps V6+, initiative-sticks, Vanguard ownership).
+- Playtest v18 rules exist in `rules_export/` — out of scope for v17 audit. Filing a future-version issue later, once v18 settles.
+
+## Footguns discovered this session
+
+None new. Previously-flagged traps (inferred-Variant ternary, `godot -s` autoload parse errors) held steady. Agent work went smoothly — delegating the page-by-page cross-reference paid off in main-context cleanliness.
+
+## Roadmap impact
+
+- Phase 5 polish is effectively done except deferred #21 bullets (sprites, camera, tooltips — non-blocking).
+- Phase 6 deploy is now gated on: #38 (in progress via the sub-issues), #40, #42 cult audit. No code-level blockers otherwise.
+- Phase 7 Cult mechanics (#29) is scoped after #42 audit.
+
+## Next pickup
+
+**#44 (grid-vs-inches decision)** is the most valuable single piece of work to resolve next — small focused discussion, followed by a decision-log entry in CLAUDE.md. Everything downstream benefits from the locked-in coord system.


### PR DESCRIPTION
First slice of the v17 rules-accuracy audit (#38). Five small corrections that stand on their own — all data / one-liner fixes with no engine-behavior coupling. Larger gaps surfaced by the audit (panic tests, retreat, two-sided combat, LoS, etc.) are filed as separate sub-issues (#44–#59).

## Changes
- **Chaff:** add `"vanguard"` to special_rules (v17 core p.31). Description updated.
- **Brutes:** remove `"vanguard"` from special_rules (v17 core p.30 — Brutes do not have it; JSON had it incorrectly).
- **Stump Gun:** `weapon_range` 48 → 60 (v17 core p.32 Round Shot is 60"; 48 was a guess). Description corrected to "2 wounds per hit" (not 3) and notes the 3D6 Grape Shot attack count. Full ammo split still pending in #38.
- **Initiative:** replace single-D6 ≤3/≥4 split with a proper roll-off — two D6, higher wins, ties re-roll (v17 core p.9).

## Housekeeping also in this PR
Per standing preference to bundle pre-merge housekeeping:
- New checkpoint `memory/checkpoint-2026-04-20-rules-audit.md` — full audit catalog, sub-issue table, sequencing decision, insights.
- `MEMORY.md` refreshed — Phase 5 done, new 5.5 rules-accuracy row, Phase 6 gates explicit (#38 + #40 + #42), next-pickup list covers the #44–#59 sequencing.
- 16 sub-issues filed from the audit, all added to the TurnipSim v0.1 project board (along with orphans #38 / #40 / #42).

## Audit confirmation from v17 change list
Cross-checked the audit against `rules_export/Change list v17.txt` (the v16→v17 delta). All data points the change list highlights are now correct: initiative sticks entire game, Bastards 2 Wounds, Whelps V=6+, Stump Gun immobile, Vanguard ownership corrected by this PR.

Also surfaced a p.20 clarification for #40 (DT tests on retreat only trigger through Follower units), commented on the issue.

## Test plan
- [x] `test_runner.gd` (19 tests)
- [x] `test_game_engine.gd` (61 tests)

No new tests added — these are pure data fixes and a loop-based dice resolution that doesn't warrant a dedicated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)