### PR TITLE
feat(engine): Euclidean distance for all range checks (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ godot/
 - **gl_compatibility renderer**: Lightest option, no Vulkan requirement
 - **`game/` no-node contract**: Everything in `game/` must be pure RefCounted — no Node, no scene tree, no signals. Safe to use from server, client, or headless tests.
 - **Runtime mode detection**: `--server` CLI arg or `dedicated_server` feature tag → `NetworkManager.is_server`
+- **Euclidean distance on integer grid**: All range/movement checks use `sqrt(dx² + dy²)` instead of Manhattan distance. 1 cell = 1 inch. Grid positions stay integer; only distance comparisons use floats. Diagonal ranges are geometrically correct. Range visualizations are circles, not diamonds. Decision made in #44.
 
 ## Phase Status
 

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -842,11 +842,13 @@ func _on_execute_confirm_pressed() -> void:
 func _has_valid_enemy_in_range(unit: Types.UnitState, reach: int) -> bool:
 	if reach <= 0:
 		return false
+	var r_sq: float = float(reach * reach)
 	for u in current_game_state.units:
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
-		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
-		if d <= reach:
+		var dx: int = u.x - unit.x
+		var dy: int = u.y - unit.y
+		if float(dx * dx + dy * dy) <= r_sq:
 			return true
 	return false
 
@@ -856,7 +858,7 @@ func _has_valid_enemy_in_range(unit: Types.UnitState, reach: int) -> bool:
 # =============================================================================
 
 ## Targets a player may legally pick in order_declare: the commanding Snob
-## itself, plus alive unordered followers within Manhattan command range.
+## itself, plus alive unordered followers within Euclidean command range.
 func _declare_valid_targets() -> Array:
 	var results: Array = []
 	var snob = _get_unit_by_id(current_game_state.current_snob_id)
@@ -865,11 +867,13 @@ func _declare_valid_targets() -> Array:
 	# Snob can always self-order
 	results.append(snob)
 	var cmd_range = snob.get_command_range()
+	var cr_sq: float = float(cmd_range * cmd_range)
 	for unit in current_game_state.units:
 		if (unit.owner_seat == my_seat and not unit.is_snob()
 				and not unit.is_dead and not unit.has_ordered):
-			var dist = abs(unit.x - snob.x) + abs(unit.y - snob.y)
-			if dist <= cmd_range:
+			var dx: int = unit.x - snob.x
+			var dy: int = unit.y - snob.y
+			if float(dx * dx + dy * dy) <= cr_sq:
 				results.append(unit)
 	return results
 

--- a/godot/client/scenes/grid_draw.gd
+++ b/godot/client/scenes/grid_draw.gd
@@ -53,11 +53,11 @@ func _draw() -> void:
 		for obj in state.objectives:
 			_draw_objective_marker(obj, cs)
 
-	# Command-range overlay: Manhattan diamond around the Made-Ready Snob.
+	# Command-range overlay: Euclidean circle around the Made-Ready Snob.
 	if state and state.order_phase == "order_declare" and state.current_snob_id != "":
 		var snob = battle_ref._get_unit_by_id(state.current_snob_id)
 		if snob and snob.x >= 0 and snob.y >= 0:
-			_draw_range_diamond(snob.x, snob.y, snob.get_command_range(), cs, bw, bh,
+			_draw_range_circle(snob.x, snob.y, snob.get_command_range(), cs, bw, bh,
 				Color(1.0, 0.95, 0.4, 0.12), Color(1.0, 0.9, 0.3, 0.8))
 
 	# Order-execute overlay: reach diamond + valid target outlines for the
@@ -93,35 +93,30 @@ func _draw_objective_marker(obj, cs: float) -> void:
 		draw_circle(center, radius * 0.35, outline)
 
 
-## Fill every cell whose Manhattan distance from (cx, cy) is ≤ range with a
-## translucent highlight, and outline the diamond boundary.
-func _draw_range_diamond(cx: int, cy: int, range_cells: int, cs: float, bw: int, bh: int, fill: Color, outline: Color) -> void:
+## Fill every cell whose Euclidean distance from (cx, cy) is ≤ range with a
+## translucent highlight, and outline the circle boundary.
+func _draw_range_circle(cx: int, cy: int, range_cells: int, cs: float, bw: int, bh: int, fill: Color, outline: Color) -> void:
 	if range_cells <= 0:
 		return
+	var r_sq: float = float(range_cells * range_cells)
 	for dy in range(-range_cells, range_cells + 1):
-		var span = range_cells - abs(dy)
 		var y = cy + dy
 		if y < 0 or y >= bh:
 			continue
-		var x_start = maxi(cx - span, 0)
-		var x_end = mini(cx + span, bw - 1)
-		draw_rect(
-			Rect2(x_start * cs, y * cs, (x_end - x_start + 1) * cs, cs),
-			fill
-		)
-	# Outline the diamond's four edges
-	var top = Vector2((cx + 0.5) * cs, (cy - range_cells) * cs)
-	var bottom = Vector2((cx + 0.5) * cs, (cy + range_cells + 1) * cs)
-	var left = Vector2((cx - range_cells) * cs, (cy + 0.5) * cs)
-	var right = Vector2((cx + range_cells + 1) * cs, (cy + 0.5) * cs)
-	draw_line(top, right, outline, 1.5)
-	draw_line(right, bottom, outline, 1.5)
-	draw_line(bottom, left, outline, 1.5)
-	draw_line(left, top, outline, 1.5)
+		for dx in range(-range_cells, range_cells + 1):
+			var x = cx + dx
+			if x < 0 or x >= bw:
+				continue
+			if float(dx * dx + dy * dy) <= r_sq:
+				draw_rect(Rect2(x * cs, y * cs, cs, cs), fill)
+	# Circle outline centered on the cell
+	var center = Vector2((cx + 0.5) * cs, (cy + 0.5) * cs)
+	var radius = (range_cells + 0.5) * cs
+	draw_arc(center, radius, 0.0, TAU, 64, outline, 1.5, true)
 
 
-## Draw reach diamond + valid-target cell outlines for the acting unit during
-## order_execute. Reach semantics mirror game_engine.gd:
+## Draw reach circle + valid-target cell outlines for the acting unit during
+## order_execute. Reach semantics mirror game_engine.gd (Euclidean distance):
 ##   volley_fire      → weapon_range from unit.pos
 ##   march            → M + move_bonus from unit.pos (no targets)
 ##   charge           → M + move_bonus from unit.pos (enemies within)
@@ -154,30 +149,30 @@ func _draw_order_execute_overlay(state, cs: float, bw: int, bh: int) -> void:
 	match order_type:
 		"volley_fire":
 			var reach = unit.base_stats.weapon_range
-			_draw_range_diamond(unit.x, unit.y, reach, cs, bw, bh, shoot_fill, shoot_outline)
+			_draw_range_circle(unit.x, unit.y, reach, cs, bw, bh, shoot_fill, shoot_outline)
 			target_cells = _enemy_cells_within(unit.x, unit.y, reach, unit.owner_seat)
 		"march":
 			var reach = unit.base_stats.movement + move_bonus
-			_draw_range_diamond(unit.x, unit.y, reach, cs, bw, bh, move_fill, move_outline)
+			_draw_range_circle(unit.x, unit.y, reach, cs, bw, bh, move_fill, move_outline)
 		"charge":
 			var reach = unit.base_stats.movement + move_bonus
-			_draw_range_diamond(unit.x, unit.y, reach, cs, bw, bh, charge_fill, charge_outline)
+			_draw_range_circle(unit.x, unit.y, reach, cs, bw, bh, charge_fill, charge_outline)
 			target_cells = _enemy_cells_within(unit.x, unit.y, reach, unit.owner_seat)
 		"move_and_shoot":
 			var max_move: int = unit.base_stats.movement
 			if blundered:
 				max_move = move_bonus
 			if battle_ref.pending_move_x < 0:
-				_draw_range_diamond(unit.x, unit.y, max_move, cs, bw, bh, move_fill, move_outline)
+				_draw_range_circle(unit.x, unit.y, max_move, cs, bw, bh, move_fill, move_outline)
 			else:
 				var px: int = battle_ref.pending_move_x
 				var py: int = battle_ref.pending_move_y
 				# Fading outline of move reach for context
-				_draw_range_diamond(unit.x, unit.y, max_move, cs, bw, bh,
+				_draw_range_circle(unit.x, unit.y, max_move, cs, bw, bh,
 					Color(0.3, 0.8, 1.0, 0.04), Color(0.4, 0.85, 1.0, 0.35))
 				# Shoot reach from the staged cell
 				var reach = unit.base_stats.weapon_range
-				_draw_range_diamond(px, py, reach, cs, bw, bh, shoot_fill, shoot_outline)
+				_draw_range_circle(px, py, reach, cs, bw, bh, shoot_fill, shoot_outline)
 				target_cells = _enemy_cells_within(px, py, reach, unit.owner_seat)
 				# Mark the staged cell itself
 				draw_rect(Rect2(px * cs, py * cs, cs, cs), Color(1.0, 1.0, 0.4, 0.25))
@@ -193,7 +188,7 @@ func _draw_order_execute_overlay(state, cs: float, bw: int, bh: int) -> void:
 		)
 
 
-## Return cell coords of alive enemies within Manhattan distance `reach` of
+## Return cell coords of alive enemies within Euclidean distance `reach` of
 ## (cx, cy). Empty when reach <= 0.
 func _enemy_cells_within(cx: int, cy: int, reach: int, own_seat: int) -> Array:
 	var out: Array = []
@@ -202,12 +197,14 @@ func _enemy_cells_within(cx: int, cy: int, reach: int, own_seat: int) -> Array:
 	var state = battle_ref.current_game_state
 	if not state:
 		return out
+	var r_sq: float = float(reach * reach)
 	for u in state.units:
 		if u.is_dead or u.owner_seat == own_seat:
 			continue
 		if u.x < 0 or u.y < 0:
 			continue
-		var d: int = abs(u.x - cx) + abs(u.y - cy)
-		if d <= reach:
+		var dx: int = u.x - cx
+		var dy: int = u.y - cy
+		if float(dx * dx + dy * dy) <= r_sq:
 			out.append(Vector2i(u.x, u.y))
 	return out

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -18,6 +18,15 @@ extends RefCounted
 const BOARD_WIDTH: int = 48
 const BOARD_HEIGHT: int = 32
 
+
+## Euclidean distance between two grid cells.
+## All range/movement checks use this instead of Manhattan distance so that
+## diagonal distances are geometrically correct (1 cell = 1 inch).
+static func _grid_distance(x1: int, y1: int, x2: int, y2: int) -> float:
+	var dx: int = x2 - x1
+	var dy: int = y2 - y1
+	return sqrt(float(dx * dx + dy * dy))
+
 # Deployment zones (4 rows each)
 const DEPLOYMENT_ZONE_1_Y_MIN: int = 28  # Bottom (seat 1)
 const DEPLOYMENT_ZONE_1_Y_MAX: int = 31
@@ -245,9 +254,9 @@ static func declare_order(state: Types.GameState, unit_id: String, order_type: S
 		if unit.is_snob():
 			result.error = "Cannot order another Snob"
 			return result
-		var distance = abs(unit.x - snob.x) + abs(unit.y - snob.y)
+		var distance = _grid_distance(snob.x, snob.y, unit.x, unit.y)
 		if distance > snob.get_command_range():
-			result.error = "Unit out of command range (%d > %d)" % [distance, snob.get_command_range()]
+			result.error = "Unit out of command range (%.1f > %d)" % [distance, snob.get_command_range()]
 			return result
 
 	# Validate order type
@@ -490,7 +499,7 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 		return result
 
 	# Range check
-	var distance = abs(target.x - unit.x) + abs(target.y - unit.y)
+	var distance = _grid_distance(unit.x, unit.y, target.x, target.y)
 	if distance > unit.base_stats.weapon_range:
 		result.error = "Target out of range (max %d)" % unit.base_stats.weapon_range
 		return result
@@ -553,7 +562,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	var max_move = unit.base_stats.movement
 	if state.current_order_blundered:
 		max_move = state.current_order_move_bonus  # D6 result stored during declare
-	var distance = abs(x - unit.x) + abs(y - unit.y)
+	var distance = _grid_distance(unit.x, unit.y, x, y)
 	if distance > max_move:
 		result.error = "Out of movement range (max %d)" % max_move
 		return result
@@ -572,7 +581,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 		new_target = _find_unit_in(new_state, target_id)
 		if new_target and not new_target.is_dead and new_target.owner_seat != unit.owner_seat:
 			# Check range from new position
-			var shoot_dist = abs(new_target.x - x) + abs(new_target.y - y)
+			var shoot_dist = _grid_distance(x, y, new_target.x, new_target.y)
 			if shoot_dist <= new_unit.base_stats.weapon_range and not new_unit.has_powder_smoke:
 				combat = _resolve_shooting(new_unit, new_target, dice_results, 0)
 
@@ -618,7 +627,7 @@ static func _execute_march(state: Types.GameState, unit: Types.UnitState, params
 
 	# March range: M + move_bonus (2D6 or 1D6 if blundered)
 	var max_move = unit.base_stats.movement + state.current_order_move_bonus
-	var distance = abs(x - unit.x) + abs(y - unit.y)
+	var distance = _grid_distance(unit.x, unit.y, x, y)
 	if distance > max_move:
 		result.error = "Out of march range (max %d = M%d + %d)" % [max_move, unit.base_stats.movement, state.current_order_move_bonus]
 		return result
@@ -688,9 +697,9 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 
 	# Charge range: M + move_bonus. Must end adjacent (distance = 1) to target.
 	var charge_range = unit.base_stats.movement + state.current_order_move_bonus
-	var target_distance = abs(target.x - unit.x) + abs(target.y - unit.y)
+	var target_distance = _grid_distance(unit.x, unit.y, target.x, target.y)
 	if target_distance > charge_range:
-		result.error = "Target out of charge range (distance %d, max %d)" % [target_distance, charge_range]
+		result.error = "Target out of charge range (distance %.1f, max %d)" % [target_distance, charge_range]
 		return result
 
 	# Find an adjacent cell to the target to move to
@@ -700,9 +709,9 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 
 	# Verify the adjacent cell is within charge range
-	var move_distance = abs(charge_dest.x - unit.x) + abs(charge_dest.y - unit.y)
+	var move_distance = _grid_distance(unit.x, unit.y, charge_dest.x, charge_dest.y)
 	if move_distance > charge_range:
-		result.error = "Cannot reach target (need %d, have %d)" % [move_distance, charge_range]
+		result.error = "Cannot reach target (need %.1f, have %d)" % [move_distance, charge_range]
 		return result
 
 	var new_state = _clone_state(state)
@@ -1033,7 +1042,7 @@ static func _has_valid_volley_target(state: Types.GameState, unit: Types.UnitSta
 	for u in state.units:
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
-		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
+		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
 		if d <= wr:
 			return true
 	return false
@@ -1047,7 +1056,7 @@ static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitSta
 	for u in state.units:
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
-		var d: int = abs(u.x - unit.x) + abs(u.y - unit.y)
+		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
 		if d <= reach:
 			return true
 	return false
@@ -1072,7 +1081,7 @@ static func get_followers_in_command_range(state: Types.GameState, snob_id: Stri
 
 	for unit in state.units:
 		if unit.owner_seat == snob.owner_seat and not unit.is_snob() and not unit.is_dead and not unit.has_ordered:
-			var distance = abs(unit.x - snob.x) + abs(unit.y - snob.y)
+			var distance = _grid_distance(snob.x, snob.y, unit.x, unit.y)
 			if distance <= cmd_range:
 				result.append(unit.id)
 
@@ -1107,7 +1116,8 @@ static func _is_objective_at(state: Types.GameState, x: int, y: int) -> bool:
 ##
 ## Rules modeled:
 ##   - Only Follower units capture (Snobs never do).
-##   - "Within 1"" maps to Manhattan distance == 1 (orthogonal neighbor).
+##   - "Within 1"" maps to Euclidean distance ≤ 1.0 (orthogonal neighbor).
+##     Diagonal neighbors (√2 ≈ 1.41) are outside 1" and do not capture.
 ##   - Objective cell itself is uncapturable-from; units can't end there.
 ##   - If only one seat has adjacent Followers → captured by that seat.
 ##   - If both seats have adjacent Followers → contested (uncaptured).
@@ -1126,8 +1136,8 @@ static func _resolve_objective_captures(state: Types.GameState) -> void:
 				continue
 			if u.x < 0 or u.y < 0:
 				continue
-			var d: int = abs(u.x - obj.x) + abs(u.y - obj.y)
-			if d == 1:
+			var d := _grid_distance(u.x, u.y, obj.x, obj.y)
+			if d <= 1.0:
 				if u.owner_seat == 1:
 					seat1_adjacent += 1
 				else:
@@ -1163,7 +1173,7 @@ static func _find_adjacent_cell(state: Types.GameState, charger: Types.UnitState
 		# Objective cells are invalid end-of-move destinations (v17 p.22).
 		if _is_objective_at(state, cx, cy):
 			continue
-		var dist = abs(cx - charger.x) + abs(cy - charger.y)
+		var dist = _grid_distance(charger.x, charger.y, cx, cy)
 		if dist < best_dist:
 			best_dist = dist
 			best = Vector2i(cx, cy)

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -158,6 +158,19 @@ func _test_declare_order() -> void:
 		return not result.success and "command range" in result.error
 	)
 
+	_test("declare_order: diagonal follower within Euclidean command range succeeds", func():
+		var state = _mock_orders_state()
+		# Toff at (10,30), command_range=6. Place Fodder diagonally:
+		# dx=4, dy=4. Euclidean = sqrt(32) ≈ 5.66 ≤ 6. In range.
+		# Manhattan would be 8 > 6 → rejected. Proves Euclidean.
+		state.units[2].x = 14; state.units[2].y = 26
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+
+		var result = GameEngine.declare_order(state, state.units[2].id, "march", 3, [3, 3])
+
+		return result.success
+	)
+
 	_test("declare_order: Snob self-order bypasses blunder check", func():
 		var state = _mock_orders_state()
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
@@ -356,6 +369,20 @@ func _test_execute_volley_fire() -> void:
 		return not result.success and "Cannot fizzle" in result.error
 	)
 
+	_test("volley_fire: diagonal target within Euclidean range is valid", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[0].base_stats.weapon_range = 18
+		# Place enemy diagonally: dx=12, dy=12. Euclidean = sqrt(288) ≈ 16.97 ≤ 18.
+		# Manhattan would be 24 > 18 → out of range. Proves Euclidean works.
+		state.units[1].x = 22; state.units[1].y = 27
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1])
+		return result.success
+	)
+
 	_test("volley_fire: multi-model unit fires one attack per model", func():
 		var state = _mock_orders_state_ranged()
 		# Make Fodder a 4-model ranged unit
@@ -491,6 +518,20 @@ func _test_execute_march() -> void:
 		var result = GameEngine.execute_order(state, {"x": 10, "y": 10}, [])
 
 		return not result.success and "march range" in result.error
+	)
+
+	_test("march: diagonal move within Euclidean range succeeds (would fail Manhattan)", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		# Self-order march, bonus = 6+4=10. Toff M=6 → max 16.
+		state = GameEngine.declare_order(state, state.units[0].id, "march", 3, [6, 4]).new_state
+
+		# (21, 26) → dx=11, dy=11. Euclidean = sqrt(242) ≈ 15.56 ≤ 16. OK.
+		# Manhattan would be 22 > 16 → rejected. This test proves Euclidean is active.
+		var result = GameEngine.execute_order(state, {"x": 21, "y": 26}, [])
+
+		return result.success and result.new_state.units[0].x == 21
 	)
 
 


### PR DESCRIPTION
## Summary

- All range, movement, and command checks now use Euclidean distance (`sqrt(dx²+dy²)`) instead of Manhattan (`abs(dx)+abs(dy)`). Diagonal distances are geometrically correct — an 18" weapon range now reaches ~12.7 cells diagonally instead of 18 Manhattan cells.
- Range visualizations in `grid_draw.gd` are circles instead of diamonds.
- Integer grid positions unchanged; only distance comparisons use floats. 1 cell = 1 inch.
- 3 new diagonal-specific tests prove the distance model is active (would fail under Manhattan).

Closes #44.

## Files changed

| File | What |
|------|------|
| `game_engine.gd` | `_grid_distance()` helper + 12 call sites updated |
| `grid_draw.gd` | `_draw_range_diamond` → `_draw_range_circle` |
| `battle.gd` | 2 client-side hint functions updated |
| `test_game_engine.gd` | 3 new diagonal Euclidean tests |
| `CLAUDE.md` | Decision recorded |

## Test plan

- [x] 64 engine tests pass (including 3 new diagonal tests)
- [x] 19 type/ruleset tests pass
- [x] Visual: launch `test-stack.sh --solo`, verify range circles render correctly during orders phase
- [x] Visual: command range circle around Made-Ready Snob
- [x] Visual: march/charge/volley fire reach circles during execute
- [ ] Gameplay: confirm diagonal movement/targeting works in a live game

🤖 Generated with [Claude Code](https://claude.com/claude-code)