### PR TITLE
feat(engine): panic test subsystem (#52)

### DIFF
--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -718,6 +718,45 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	var new_unit = _find_unit_in(new_state, unit.id)
 	var new_target = _find_unit_in(new_state, target_id)
 
+	# v17 core p.16: target takes panic test when charged.
+	var panic_die: int = params.get("panic_die", 1)
+	var fearless_die: int = params.get("fearless_die", 1)
+	var panic = _panic_test(new_target, panic_die, fearless_die)
+
+	if not panic["passed"]:
+		# Target failed panic test — gains +1 panic token (v17 p.19).
+		# Full retreat movement deferred to #53; for now charger moves
+		# adjacent and melee is skipped (represents target fleeing).
+		new_target.panic_tokens = mini(new_target.panic_tokens + 1, 6)
+		new_unit.x = charge_dest.x
+		new_unit.y = charge_dest.y
+
+		_advance_after_order(new_state)
+
+		new_state.action_log.append({
+			"round": state.current_round,
+			"seat": state.active_seat,
+			"action": "charge",
+			"unit_id": unit.id,
+			"unit_type": unit.unit_type,
+			"target_id": target_id,
+			"target_type": target.unit_type,
+			"charge_range": charge_range,
+			"blundered": state.current_order_blundered,
+			"panic_test": panic,
+			"target_fled": true,
+			"hits": 0, "saves": 0, "unsaved_wounds": 0
+		})
+
+		result.success = true
+		result.new_state = new_state
+		result.dice_rolled = [panic_die, fearless_die]
+		var fearless_text = " (Fearless failed)" if panic["used_fearless"] else ""
+		result.description = "Charge! %s → %s — target panicked and fled!%s" % [
+			unit.unit_type, target.unit_type, fearless_text
+		]
+		return result
+
 	# Move to adjacent cell
 	new_unit.x = charge_dest.x
 	new_unit.y = charge_dest.y
@@ -730,6 +769,10 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 
 	_advance_after_order(new_state)
 
+	var panic_log = {}
+	if not panic["auto_passed"]:
+		panic_log = panic
+
 	new_state.action_log.append({
 		"round": state.current_round,
 		"seat": state.active_seat,
@@ -740,6 +783,8 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		"target_type": target.unit_type,
 		"charge_range": charge_range,
 		"blundered": state.current_order_blundered,
+		"panic_test": panic_log,
+		"target_fled": false,
 		"hits": combat["hits"],
 		"saves": combat["saves"],
 		"unsaved_wounds": combat["unsaved_wounds"]
@@ -747,9 +792,14 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 
 	result.success = true
 	result.new_state = new_state
-	result.dice_rolled = dice_results
-	result.description = "Charge! %s → %s (%d hits, %d saved, %d wounds)%s" % [
-		unit.unit_type, target.unit_type,
+	result.dice_rolled = [panic_die, fearless_die] + dice_results
+	var panic_text = ""
+	if panic["fearless_override"]:
+		panic_text = " (target Fearless — held!)"
+	elif not panic["auto_passed"]:
+		panic_text = " (target passed panic test)"
+	result.description = "Charge! %s → %s%s (%d hits, %d saved, %d wounds)%s" % [
+		unit.unit_type, target.unit_type, panic_text,
 		combat["hits"], combat["saves"], combat["unsaved_wounds"],
 		" [DESTROYED]" if new_target.is_dead else ""
 	]
@@ -836,6 +886,65 @@ static func _end_round(state: Types.GameState) -> void:
 		"round": state.current_round - 1,
 		"action": "round_ended"
 	})
+
+
+# =============================================================================
+# PANIC TEST
+# =============================================================================
+
+## Check whether a unit is currently Fearless (3+ to ignore forced retreat).
+## Sources: "fearless" special rule (Brutes), or "safety_in_numbers" with 8+
+## models alive (Fodder).
+static func _is_fearless(unit: Types.UnitState) -> bool:
+	if "fearless" in unit.special_rules:
+		return true
+	if "safety_in_numbers" in unit.special_rules and unit.model_count >= 8:
+		return true
+	return false
+
+
+## Panic test per v17 core p.19.
+## Roll D6 + panic_tokens: ≤6 pass, ≥7 fail (must retreat).
+## Natural 1 always passes. 0 tokens auto-pass (skip test).
+## Fearless units that fail get a second chance: fearless_die 3+ = override to pass.
+##
+## Returns { passed, roll, total, auto_passed, fearless_override, used_fearless }.
+## Does NOT modify unit state — caller applies consequences.
+static func _panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int) -> Dictionary:
+	var result = {
+		"passed": true,
+		"roll": panic_die,
+		"total": 0,
+		"auto_passed": false,
+		"fearless_override": false,
+		"used_fearless": false,
+	}
+
+	# 0 tokens = auto-pass (v17: "units with zero panic tokens can skip the test")
+	if unit.panic_tokens == 0:
+		result["auto_passed"] = true
+		return result
+
+	# Natural 1 always passes
+	if panic_die == 1:
+		return result
+
+	var total: int = panic_die + unit.panic_tokens
+	result["total"] = total
+
+	if total <= 6:
+		# Passed normally
+		return result
+
+	# Failed — check Fearless override
+	if _is_fearless(unit):
+		result["used_fearless"] = true
+		if fearless_die >= 3:
+			result["fearless_override"] = true
+			return result
+
+	result["passed"] = false
+	return result
 
 
 # =============================================================================

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -293,6 +293,10 @@ func request_action(action_data: Dictionary) -> void:
 
 		"execute_order":
 			var params = action_data.get("params", {})
+			# Charge: server rolls panic test + fearless dice for the target.
+			if state.current_order_type == "charge" and not params.get("fizzle", false):
+				params["panic_die"] = _roll_d6()
+				params["fearless_die"] = _roll_d6()
 			var dice = _roll_execute_dice(state)
 			result = GameEngine.execute_order(state, params, dice)
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -20,6 +20,7 @@ func _init() -> void:
 	_test_execute_move_and_shoot()
 	_test_execute_march()
 	_test_execute_charge()
+	_test_panic_test()
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
@@ -606,6 +607,132 @@ func _test_execute_charge() -> void:
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
 		return not result.success and "Cannot fizzle" in result.error
+	)
+
+
+func _test_panic_test() -> void:
+	print("\n[Test Suite: Panic Test]")
+
+	_test("panic_test: 0 tokens auto-passes", func():
+		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		unit.panic_tokens = 0
+		var result = GameEngine._panic_test(unit, 6, 1)
+		return result["passed"] and result["auto_passed"]
+	)
+
+	_test("panic_test: natural 1 always passes regardless of tokens", func():
+		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		unit.panic_tokens = 6  # max tokens, but die=1 → pass
+		var result = GameEngine._panic_test(unit, 1, 1)
+		return result["passed"] and not result["auto_passed"]
+	)
+
+	_test("panic_test: D6 + tokens <= 6 passes", func():
+		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		unit.panic_tokens = 3  # die=3, total=6 ≤ 6 → pass
+		var result = GameEngine._panic_test(unit, 3, 1)
+		return result["passed"] and result["total"] == 6
+	)
+
+	_test("panic_test: D6 + tokens >= 7 fails", func():
+		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		unit.panic_tokens = 3  # die=4, total=7 ≥ 7 → fail
+		var result = GameEngine._panic_test(unit, 4, 1)
+		return not result["passed"] and result["total"] == 7
+	)
+
+	_test("panic_test: Fearless unit overrides fail on 3+", func():
+		var stats = Types.Stats.new(6, 2, 5, 1, 5, 18)
+		var rules: Array[String] = ["fearless"]
+		var unit = Types.UnitState.new("u0", 1, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
+		unit.panic_tokens = 4  # die=5, total=9 → fail, but Fearless 3+ saves
+		var result = GameEngine._panic_test(unit, 5, 3)
+		return result["passed"] and result["fearless_override"] and result["used_fearless"]
+	)
+
+	_test("panic_test: Fearless unit fails override on 1-2", func():
+		var stats = Types.Stats.new(6, 2, 5, 1, 5, 18)
+		var rules: Array[String] = ["fearless"]
+		var unit = Types.UnitState.new("u0", 1, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
+		unit.panic_tokens = 4  # die=5, total=9 → fail, Fearless die=2 → still fails
+		var result = GameEngine._panic_test(unit, 5, 2)
+		return not result["passed"] and result["used_fearless"] and not result["fearless_override"]
+	)
+
+	_test("panic_test: Safety in Numbers grants Fearless at 8+ models", func():
+		var stats = Types.Stats.new(6, 1, 6, 1, 6, 0)
+		var rules: Array[String] = ["safety_in_numbers"]
+		var unit = Types.UnitState.new("u0", 1, "Fodder", "infantry", 8, 12, stats, "black_powder", rules)
+		unit.panic_tokens = 4
+		var result = GameEngine._panic_test(unit, 5, 4)  # total=9, Fearless die=4 → override
+		return result["passed"] and result["fearless_override"]
+	)
+
+	_test("panic_test: Safety in Numbers loses Fearless below 8 models", func():
+		var stats = Types.Stats.new(6, 1, 6, 1, 6, 0)
+		var rules: Array[String] = ["safety_in_numbers"]
+		var unit = Types.UnitState.new("u0", 1, "Fodder", "infantry", 7, 12, stats, "black_powder", rules)
+		unit.panic_tokens = 4
+		var result = GameEngine._panic_test(unit, 5, 4)  # total=9, but not Fearless → fails
+		return not result["passed"] and not result["used_fearless"]
+	)
+
+	# -- Charge integration --
+
+	_test("charge: target with panic tokens fails test and flees (no melee)", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 15; state.units[1].y = 10
+		state.units[1].panic_tokens = 4  # die=4 → total=8 ≥ 7 → fail
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var params = {"target_id": state.units[1].id, "panic_die": 4, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
+
+		return (result.success
+			and result.new_state.units[0].x == 14  # charger still moved adjacent
+			and not result.new_state.units[1].is_dead  # no melee happened
+			and result.new_state.units[1].panic_tokens == 5  # +1 from failed test
+			and result.new_state.units[1].current_wounds == 0)
+	)
+
+	_test("charge: target passes panic test, melee resolves normally", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 15; state.units[1].y = 10
+		state.units[1].panic_tokens = 2  # die=3 → total=5 ≤ 6 → pass
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var params = {"target_id": state.units[1].id, "panic_die": 3, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
+
+		return (result.success
+			and result.new_state.units[1].is_dead  # melee resolved, target killed
+			and result.new_state.units[1].panic_tokens == 2)  # no extra panic
+	)
+
+	_test("charge: Fearless target holds despite failed panic roll", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		# Replace u1 with Brutes (Fearless)
+		var stats = Types.Stats.new(6, 2, 5, 2, 5, 18)
+		var rules: Array[String] = ["fearless"]
+		state.units[1] = Types.UnitState.new("u1", 2, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
+		state.units[1].x = 15; state.units[1].y = 10
+		state.units[1].panic_tokens = 4  # die=5 → total=9, Fearless die=3 → override
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var params = {"target_id": state.units[1].id, "panic_die": 5, "fearless_die": 3}
+		# Toff A=2, 1 model → 2 attacks → 4 dice needed (2 inac + 2 vuln)
+		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
+
+		return (result.success
+			and result.new_state.units[0].x == 14  # charger moved
+			and result.new_state.units[1].panic_tokens == 4  # no extra panic (passed)
+			and result.new_state.units[1].model_count < 6)  # melee happened, took casualties
 	)
 
 


### PR DESCRIPTION
## Summary

- Panic test per v17 core p.19: `D6 + panic_tokens >= 7` = fail (must retreat). Natural 1 always passes. 0 tokens auto-pass.
- Fearless gate: Brutes (`fearless` special rule) or Fodder with 8+ models (`safety_in_numbers`) get a 3+ override roll on failure.
- Wired into charge: target takes panic test before melee. Fail = +1 panic token, charger moves adjacent, melee skipped. Pass = melee as normal.
- Server rolls `panic_die` + `fearless_die` for charge `execute_order`.

## Deferred

- Bowel-Loosening Charge reroll (needs #49 reroll infra)
- Actual retreat movement (needs #53)
- Panic from shooting/melee loss (needs #40, #55)

Closes #52.

## Files changed

| File | What |
|------|------|
| `game_engine.gd` | `_panic_test()`, `_is_fearless()`, charge integration |
| `network_server.gd` | Roll 2 extra D6 for charge panic/fearless |
| `test_game_engine.gd` | 11 new tests (8 unit + 3 charge integration) |

## Test plan

- [x] 75 engine tests pass (including 11 new panic tests)
- [x] 19 type/ruleset tests pass
- [ ] Visual: solo stack charge with panicked target — confirm order resolves without crash
- [ ] Visual: charge against 0-token target — confirm melee still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)