### PR TITLE
feat(engine): retreat subsystem (#53)

### DIFF
--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -724,10 +724,14 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	var panic = _panic_test(new_target, panic_die, fearless_die)
 
 	if not panic["passed"]:
-		# Target failed panic test — gains +1 panic token (v17 p.19).
-		# Full retreat movement deferred to #53; for now charger moves
-		# adjacent and melee is skipped (represents target fleeing).
+		# Target failed panic test — gains +1 panic token (v17 p.19),
+		# then retreats away from nearest enemy. Charger moves to the
+		# now-vacated adjacent cell. No melee.
 		new_target.panic_tokens = mini(new_target.panic_tokens + 1, 6)
+		var retreat = _execute_retreat(new_state, target_id)
+
+		# Charger advances to adjacent cell (target may have vacated it,
+		# or stayed put if Stubborn Fanatics).
 		new_unit.x = charge_dest.x
 		new_unit.y = charge_dest.y
 
@@ -745,15 +749,23 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 			"blundered": state.current_order_blundered,
 			"panic_test": panic,
 			"target_fled": true,
+			"retreat": retreat,
 			"hits": 0, "saves": 0, "unsaved_wounds": 0
 		})
 
 		result.success = true
 		result.new_state = new_state
 		result.dice_rolled = [panic_die, fearless_die]
+		var retreat_text = ""
+		if retreat["destroyed"]:
+			retreat_text = " — fled off board! [DESTROYED]"
+		elif retreat["stubborn_held"]:
+			retreat_text = " — Stubborn Fanatics held!"
+		elif retreat["retreated"]:
+			retreat_text = " — retreated to (%d,%d)" % [retreat["to_x"], retreat["to_y"]]
 		var fearless_text = " (Fearless failed)" if panic["used_fearless"] else ""
-		result.description = "Charge! %s → %s — target panicked and fled!%s" % [
-			unit.unit_type, target.unit_type, fearless_text
+		result.description = "Charge! %s → %s — target panicked%s%s" % [
+			unit.unit_type, target.unit_type, fearless_text, retreat_text
 		]
 		return result
 
@@ -945,6 +957,150 @@ static func _panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int
 
 	result["passed"] = false
 	return result
+
+
+# =============================================================================
+# RETREAT
+# =============================================================================
+
+## Execute retreat for a unit. Mutates state in place.
+## v17 core p.20: move directly away from closest enemy, 2" per panic token
+## (min 1"). Board edge = unit destroyed. Stubborn Fanatics never retreat.
+##
+## Returns { retreated, destroyed, from_x, from_y, to_x, to_y, distance,
+##           stubborn_held }.
+## DT tests for crossing Followers deferred to terrain system (#58).
+static func _execute_retreat(state: Types.GameState, unit_id: String) -> Dictionary:
+	var unit = _find_unit_in(state, unit_id)
+	var result = {
+		"retreated": false,
+		"destroyed": false,
+		"from_x": unit.x, "from_y": unit.y,
+		"to_x": unit.x, "to_y": unit.y,
+		"distance": 0,
+		"stubborn_held": false,
+	}
+
+	if not unit or unit.is_dead:
+		return result
+
+	# Stubborn Fanatics: never retreat (Stump Gun)
+	if "stubborn_fanatics" in unit.special_rules:
+		result["stubborn_held"] = true
+		return result
+
+	# Retreat distance: 2" per panic token, minimum 1
+	var retreat_dist: int = maxi(unit.panic_tokens * 2, 1)
+	result["distance"] = retreat_dist
+
+	# Direction: away from nearest alive enemy
+	var nearest_enemy = _find_nearest_enemy(state, unit)
+	if not nearest_enemy:
+		# No enemies alive — nowhere to retreat from. Stay put.
+		return result
+
+	var dx: float = float(unit.x - nearest_enemy.x)
+	var dy: float = float(unit.y - nearest_enemy.y)
+	var dist: float = sqrt(dx * dx + dy * dy)
+	if dist < 0.001:
+		# On top of enemy (shouldn't happen). Default retreat direction: toward own deployment zone.
+		dy = 1.0 if unit.owner_seat == 1 else -1.0
+		dx = 0.0
+		dist = 1.0
+
+	# Normalize direction
+	dx /= dist
+	dy /= dist
+
+	# Ideal retreat destination
+	var ideal_x: float = float(unit.x) + dx * float(retreat_dist)
+	var ideal_y: float = float(unit.y) + dy * float(retreat_dist)
+	var target_x: int = clampi(roundi(ideal_x), 0, BOARD_WIDTH - 1)
+	var target_y: int = clampi(roundi(ideal_y), 0, BOARD_HEIGHT - 1)
+
+	# Board edge check: if the ideal position is off the board, unit is destroyed.
+	if roundi(ideal_x) < 0 or roundi(ideal_x) >= BOARD_WIDTH or roundi(ideal_y) < 0 or roundi(ideal_y) >= BOARD_HEIGHT:
+		unit.is_dead = true
+		unit.model_count = 0
+		unit.x = -1
+		unit.y = -1
+		result["retreated"] = true
+		result["destroyed"] = true
+		result["to_x"] = -1
+		result["to_y"] = -1
+		return result
+
+	# Find the best valid cell near the target
+	var dest = _find_retreat_cell(state, unit, target_x, target_y)
+	if dest.x == -1:
+		# No valid cell found — stay in place (edge case, shouldn't normally happen)
+		return result
+
+	unit.x = dest.x
+	unit.y = dest.y
+	result["retreated"] = true
+	result["to_x"] = dest.x
+	result["to_y"] = dest.y
+	return result
+
+
+## Find the nearest alive enemy unit to the given unit.
+static func _find_nearest_enemy(state: Types.GameState, unit: Types.UnitState) -> Types.UnitState:
+	var best: Types.UnitState = null
+	var best_dist: float = 99999.0
+	for u in state.units:
+		if u.is_dead or u.owner_seat == unit.owner_seat:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
+		if d < best_dist:
+			best_dist = d
+			best = u
+	return best
+
+
+## Find a valid retreat destination cell near (target_x, target_y).
+## Searches the target cell first, then spirals outward. Returns Vector2i(-1,-1)
+## if nothing found within a reasonable radius.
+static func _find_retreat_cell(state: Types.GameState, unit: Types.UnitState, target_x: int, target_y: int) -> Vector2i:
+	# Try the ideal cell first
+	if _is_valid_retreat_dest(state, unit, target_x, target_y):
+		return Vector2i(target_x, target_y)
+
+	# Spiral outward looking for an alternative
+	for radius in range(1, 6):
+		var best = Vector2i(-1, -1)
+		var best_dist: float = 99999.0
+		for dy in range(-radius, radius + 1):
+			for dx in range(-radius, radius + 1):
+				if abs(dx) != radius and abs(dy) != radius:
+					continue  # Skip inner cells already checked
+				var cx: int = target_x + dx
+				var cy: int = target_y + dy
+				if _is_valid_retreat_dest(state, unit, cx, cy):
+					var d := _grid_distance(target_x, target_y, cx, cy)
+					if d < best_dist:
+						best_dist = d
+						best = Vector2i(cx, cy)
+		if best.x != -1:
+			return best
+
+	return Vector2i(-1, -1)
+
+
+## Is this cell a valid retreat destination?
+static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> bool:
+	if x < 0 or x >= BOARD_WIDTH or y < 0 or y >= BOARD_HEIGHT:
+		return false
+	# Can't land on an occupied cell
+	for u in state.units:
+		if not u.is_dead and u.id != unit.id and u.x == x and u.y == y:
+			return false
+	# Can't land on an objective (v17 p.22)
+	if _is_objective_at(state, x, y):
+		return false
+	return true
 
 
 # =============================================================================

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -21,6 +21,7 @@ func _init() -> void:
 	_test_execute_march()
 	_test_execute_charge()
 	_test_panic_test()
+	_test_retreat()
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
@@ -690,10 +691,16 @@ func _test_panic_test() -> void:
 		var params = {"target_id": state.units[1].id, "panic_die": 4, "fearless_die": 1}
 		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
 
+		# After +1 panic token, target has 5 tokens → retreat 10 cells (2×5).
+		# Target was at (15,10), nearest enemy (charger) at (10,10).
+		# Retreat direction: away from charger → positive X.
+		# Ideal destination: (25, 10).
 		return (result.success
-			and result.new_state.units[0].x == 14  # charger still moved adjacent
+			and result.new_state.units[0].x == 14  # charger moved adjacent
 			and not result.new_state.units[1].is_dead  # no melee happened
 			and result.new_state.units[1].panic_tokens == 5  # +1 from failed test
+			and result.new_state.units[1].x == 25  # retreated 10 cells right
+			and result.new_state.units[1].y == 10
 			and result.new_state.units[1].current_wounds == 0)
 	)
 
@@ -733,6 +740,90 @@ func _test_panic_test() -> void:
 			and result.new_state.units[0].x == 14  # charger moved
 			and result.new_state.units[1].panic_tokens == 4  # no extra panic (passed)
 			and result.new_state.units[1].model_count < 6)  # melee happened, took casualties
+	)
+
+
+func _test_retreat() -> void:
+	print("\n[Test Suite: Retreat]")
+
+	_test("retreat: moves away from nearest enemy by 2x panic tokens", func():
+		var state = _mock_orders_state()
+		# Unit at (20,15), enemy at (15,15). Retreat direction: +X.
+		# 3 tokens → distance 6.
+		state.units[2].x = 20; state.units[2].y = 15
+		state.units[2].panic_tokens = 3
+		state.units[1].x = 15; state.units[1].y = 15  # nearest enemy
+		var result = GameEngine._execute_retreat(state, state.units[2].id)
+		return (result["retreated"]
+			and state.units[2].x == 26  # 20 + 6
+			and state.units[2].y == 15)
+	)
+
+	_test("retreat: diagonal direction works correctly", func():
+		var state = _mock_orders_state()
+		# Unit at (20,20), enemy at (17,17). Direction: +X,+Y (normalized).
+		# 2 tokens → distance 4. Diagonal: 4/√2 ≈ 2.83 each axis → (23,23).
+		state.units[2].x = 20; state.units[2].y = 20
+		state.units[2].panic_tokens = 2
+		state.units[1].x = 17; state.units[1].y = 17
+		var result = GameEngine._execute_retreat(state, state.units[2].id)
+		return (result["retreated"]
+			and state.units[2].x == 23  # round(20 + 4*0.707) = round(22.83) = 23
+			and state.units[2].y == 23)
+	)
+
+	_test("retreat: min distance is 1 even with 0 panic tokens", func():
+		var state = _mock_orders_state()
+		state.units[2].x = 20; state.units[2].y = 15
+		state.units[2].panic_tokens = 0  # min(0*2, 1) = 1
+		state.units[1].x = 15; state.units[1].y = 15
+		var result = GameEngine._execute_retreat(state, state.units[2].id)
+		return (result["retreated"]
+			and result["distance"] == 1
+			and state.units[2].x == 21)
+	)
+
+	_test("retreat: board edge destroys unit", func():
+		var state = _mock_orders_state()
+		# Unit at (46,15), enemy at (44,15). Retreat direction: +X.
+		# 3 tokens → distance 6. Ideal dest: (52,15) → off board → destroyed.
+		state.units[2].x = 46; state.units[2].y = 15
+		state.units[2].panic_tokens = 3
+		state.units[1].x = 44; state.units[1].y = 15
+		var result = GameEngine._execute_retreat(state, state.units[2].id)
+		return (result["retreated"]
+			and result["destroyed"]
+			and state.units[2].is_dead
+			and state.units[2].model_count == 0)
+	)
+
+	_test("retreat: Stubborn Fanatics never retreat", func():
+		var state = _mock_orders_state()
+		var stats = Types.Stats.new(0, 3, 6, 3, 5, 60)
+		var rules: Array[String] = ["immobile", "stubborn_fanatics"]
+		var stump = Types.UnitState.new("stump", 1, "Stump Gun", "artillery", 1, 1, stats, "black_powder", rules)
+		stump.x = 20; stump.y = 15
+		stump.panic_tokens = 4
+		state.units.append(stump)
+		state.units[1].x = 15; state.units[1].y = 15
+		var result = GameEngine._execute_retreat(state, "stump")
+		return (result["stubborn_held"]
+			and not result["retreated"]
+			and stump.x == 20 and stump.y == 15)
+	)
+
+	_test("retreat: avoids occupied cells", func():
+		var state = _mock_orders_state()
+		# Unit at (20,15), enemy at (18,15). Retreat direction: +X.
+		# 1 token → distance 2. Ideal dest: (22,15).
+		# Place a blocker at (22,15).
+		state.units[2].x = 20; state.units[2].y = 15
+		state.units[2].panic_tokens = 1
+		state.units[1].x = 18; state.units[1].y = 15
+		state.units[3].x = 22; state.units[3].y = 15  # blocker at ideal dest
+		var result = GameEngine._execute_retreat(state, state.units[2].id)
+		return (result["retreated"]
+			and state.units[2].x != 22 or state.units[2].y != 15)  # didn't land on blocker
 	)
 
 


### PR DESCRIPTION
## Summary

- Retreat movement per v17 core p.20: move directly away from nearest enemy, distance = 2" × panic_tokens (min 1")
- Board edge = unit destroyed (model_count → 0, is_dead)
- Stubborn Fanatics (Stump Gun) never retreat — stays in place
- Spiral search for valid destination (avoids occupied cells, objectives)
- Wired into charge: failed panic test now triggers real retreat (replaces interim melee-skip)

Closes #53.

## Deferred

- DT tests when retreating through Followers (#62, filed this session)
- Impassable terrain crush (#58)
- Shooting/melee retreat triggers (#40, #55)

## Files changed

| File | What |
|------|------|
| `game_engine.gd` | `_execute_retreat()`, `_find_retreat_cell()`, `_find_nearest_enemy()`, `_is_valid_retreat_dest()`, charge integration |
| `network_server.gd` | No changes needed (retreat is deterministic, no extra dice) |
| `test_game_engine.gd` | 6 new retreat tests + 1 updated charge integration |

## Test plan

- [x] 81 engine tests pass (6 new retreat + 1 updated charge panic)
- [x] 19 type/ruleset tests pass
- [ ] Visual: solo stack charge against panicked target — target visibly moves away
- [ ] Visual: charge near board edge with panicked target — target destroyed

🤖 Generated with [Claude Code](https://claude.com/claude-code)