### PR TITLE
feat(engine): two-sided melee bouts with counter-attack (#55)

### DIFF
--- a/docs/wiki/Codebase-Tour.md
+++ b/docs/wiki/Codebase-Tour.md
@@ -208,10 +208,9 @@ Each class has:
 - Ruleset loading, army rolling, determinism
 - Run with: `godot --headless -s tests/test_runner.gd`
 
-**test_game_engine.gd** (~577 lines, 38 tests)
+**test_game_engine.gd** (~1300 lines, 89 tests, all passing)
 - Phase 4 engine tests
-- Placement, movement, shooting, melee, turns, victory
-- 28/34 currently passing
+- Placement, movement, shooting, melee bouts, panic, retreat, turns, victory, objectives
 - Run with: `godot --headless -s tests/test_game_engine.gd`
 
 **test_ui_instantiate.gd** (~50 lines)

--- a/docs/wiki/Manual-Testing-Guide.md
+++ b/docs/wiki/Manual-Testing-Guide.md
@@ -72,7 +72,7 @@ Each round, players alternate picking Snobs to "Make Ready." The sidebar is phas
 - Sidebar shows the declared order, blundered state, and movement range with dice bonus applied.
 - **Volley Fire:** click an enemy unit to fire (`-1 Inaccuracy` unless blundered).
 - **March:** click a destination cell within `M + move_bonus`.
-- **Charge:** click an enemy within `M + move_bonus`; attacker auto-pathfinds to an adjacent cell and resolves melee.
+- **Charge:** click an enemy within `M + move_bonus`; attacker auto-pathfinds to an adjacent cell and resolves melee as bouts (v17 p.18) — attacker strikes, defender removes casualties, defender counter-strikes, winner = more unsaved wounds per bout. Tied bouts repeat up to 3×; cap-hit ties draw with no retreat. Post-melee both survivors gain +1 panic; the loser retreats (which can include the charger).
 - **Move & Shoot:** click a destination (max `M`, or `1D6` if blundered), then click an enemy to fire from the new position *or* press **Confirm move (no shot)** to skip the shot.
 
 On success the turn either passes to the opposing seat (if they still have unordered Snobs), or — once both sides' Snobs are done — transitions to `follower_self_order`.
@@ -127,6 +127,7 @@ The fastest way to force each path without an hour-long game:
 | Order button enable state | Disabled for invalid orders (volley_fire with no range, etc.) | Button stays enabled → server rejects the action |
 | Blunder panic | `+1 panic` in unit info when order blundered | Panic not applied |
 | Charge panic test | Target with panic tokens may fail (D6+tokens ≥ 7). Failed = +1 panic token, target retreats away from charger (2" per token), melee skipped. Fearless (Brutes, Fodder 8+) get 3+ override. 0-token targets auto-pass. Board edge retreat = destroyed. | Panic test not logged, target doesn't move on failed test, melee always resolves |
+| Melee bouts | Target passes panic → bout loop runs: attacker strikes, defender removes dead, defender counter-strikes (if alive), attacker removes dead. Winner = more unsaved wounds that bout; tied bouts repeat up to 3 before draw. Both survivors +1 panic after the melee; loser retreats (charger can end up retreating instead of holding the cell). | Only one side rolls, no counter-attack, melee always ends after one pass, charger always holds the cell regardless of outcome |
 | Move & Shoot two-click | Destination staged → Confirm button appears | Confirm never appears, or first click executes immediately |
 | Round advance | `has_ordered` clears on all units, powder smoke gone | Units stay marked ordered across rounds |
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -33,6 +33,11 @@ const DEPLOYMENT_ZONE_1_Y_MAX: int = 31
 const DEPLOYMENT_ZONE_2_Y_MIN: int = 0   # Top (seat 2)
 const DEPLOYMENT_ZONE_2_Y_MAX: int = 3
 
+# Melee bout cap — v17 has no hard limit, but tied bouts could loop forever on
+# whiffing dice. Cap at 3; unresolved ties after the cap end in a draw with no
+# retreat (both sides still take +1 panic per melee-ended rule).
+const MELEE_MAX_BOUTS: int = 3
+
 
 # =============================================================================
 # PLACEMENT PHASE
@@ -773,17 +778,40 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	new_unit.x = charge_dest.x
 	new_unit.y = charge_dest.y
 
-	# Resolve melee
+	# Resolve melee as bouts (v17 core p.18)
 	var combat = _resolve_melee(new_unit, new_target, dice_results)
 	if combat["error"] != "":
 		result.error = combat["error"]
 		return result
+
+	# Post-melee: both participants gain +1 panic token (v17 p.18 + p.19).
+	if not new_unit.is_dead:
+		new_unit.panic_tokens = mini(new_unit.panic_tokens + 1, 6)
+	if not new_target.is_dead:
+		new_target.panic_tokens = mini(new_target.panic_tokens + 1, 6)
+
+	# Loser retreats. Draw (bout cap with no winner) = no retreat.
+	var retreat: Dictionary = {}
+	var charger_retreated: bool = false
+	if not combat["draw"] and combat["loser_id"] != "":
+		var loser = _find_unit_in(new_state, combat["loser_id"])
+		if loser and not loser.is_dead:
+			retreat = _execute_retreat(new_state, combat["loser_id"])
+			if combat["loser_id"] == new_unit.id:
+				charger_retreated = true
 
 	_advance_after_order(new_state)
 
 	var panic_log = {}
 	if not panic["auto_passed"]:
 		panic_log = panic
+
+	# Aggregate wounds across bouts for legacy log fields.
+	var atk_wounds_total: int = 0
+	var def_wounds_total: int = 0
+	for b in combat["bouts"]:
+		atk_wounds_total += b["atk_wounds"]
+		def_wounds_total += b["def_wounds"]
 
 	new_state.action_log.append({
 		"round": state.current_round,
@@ -797,9 +825,14 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		"blundered": state.current_order_blundered,
 		"panic_test": panic_log,
 		"target_fled": false,
-		"hits": combat["hits"],
-		"saves": combat["saves"],
-		"unsaved_wounds": combat["unsaved_wounds"]
+		"bouts": combat["bouts"],
+		"melee_draw": combat["draw"],
+		"melee_winner_id": combat["winner_id"],
+		"melee_loser_id": combat["loser_id"],
+		"retreat": retreat,
+		"charger_retreated": charger_retreated,
+		"unsaved_wounds": atk_wounds_total,
+		"counter_unsaved_wounds": def_wounds_total,
 	})
 
 	result.success = true
@@ -810,10 +843,28 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		panic_text = " (target Fearless — held!)"
 	elif not panic["auto_passed"]:
 		panic_text = " (target passed panic test)"
-	result.description = "Charge! %s → %s%s (%d hits, %d saved, %d wounds)%s" % [
-		unit.unit_type, target.unit_type, panic_text,
-		combat["hits"], combat["saves"], combat["unsaved_wounds"],
-		" [DESTROYED]" if new_target.is_dead else ""
+
+	var outcome_text: String
+	if combat["draw"]:
+		outcome_text = "drawn after %d bouts" % combat["bouts"].size()
+	elif combat["winner_id"] == new_unit.id:
+		outcome_text = "charger won in %d bout(s)" % combat["bouts"].size()
+		if new_target.is_dead:
+			outcome_text += " [DEFENDER DESTROYED]"
+		elif retreat.get("destroyed", false):
+			outcome_text += " — defender fled off board [DESTROYED]"
+		elif retreat.get("stubborn_held", false):
+			outcome_text += " — defender Stubborn, held ground"
+	else:
+		outcome_text = "charger lost in %d bout(s)" % combat["bouts"].size()
+		if new_unit.is_dead:
+			outcome_text += " [CHARGER DESTROYED]"
+		elif retreat.get("destroyed", false):
+			outcome_text += " — charger fled off board [DESTROYED]"
+
+	result.description = "Charge! %s → %s%s — %s (atk %d / def %d wounds)" % [
+		unit.unit_type, target.unit_type, panic_text, outcome_text,
+		atk_wounds_total, def_wounds_total,
 	]
 
 	return result
@@ -1150,28 +1201,31 @@ static func _resolve_shooting(attacker: Types.UnitState, target: Types.UnitState
 	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds, "error": ""}
 
 
-## Resolve a melee engagement. Modifies new_attacker and new_target in place.
-static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array) -> Dictionary:
+## Resolve one side's attacks in a melee bout. Consumes dice from the pool
+## starting at `offset`. Returns { hits, saves, unsaved_wounds, dice_used, error }.
+## Mutates `defender` via _apply_wounds.
+static func _resolve_bout_side(attacker: Types.UnitState, defender: Types.UnitState, dice_results: Array, offset: int) -> Dictionary:
 	var attacks_per_model = attacker.base_stats.attacks
 	var inaccuracy = attacker.base_stats.inaccuracy
-	var vulnerability = target.base_stats.vulnerability
+	var vulnerability = defender.base_stats.vulnerability
 
-	# Close combat equipment reduces inaccuracy by 1
+	# Close combat equipment reduces inaccuracy by 1 (min 2)
 	if attacker.equipment == "close_combat":
 		inaccuracy = maxi(inaccuracy - 1, 2)
 
 	var num_attacks = attacker.model_count * attacks_per_model
 	var needed_dice = num_attacks * 2
-	if dice_results.size() < needed_dice:
-		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "error": "Not enough dice (need %d, got %d)" % [needed_dice, dice_results.size()]}
+	if dice_results.size() - offset < needed_dice:
+		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
+				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
 
 	var hits = 0
 	var saves = 0
 	var unsaved_wounds = 0
 
 	for i in range(num_attacks):
-		var inac_roll = dice_results[i]
-		var vuln_roll = dice_results[num_attacks + i]
+		var inac_roll = dice_results[offset + i]
+		var vuln_roll = dice_results[offset + num_attacks + i]
 		if inac_roll >= inaccuracy:
 			hits += 1
 			if vuln_roll >= vulnerability:
@@ -1179,9 +1233,112 @@ static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, d
 			else:
 				unsaved_wounds += 1
 
-	_apply_wounds(target, unsaved_wounds)
+	_apply_wounds(defender, unsaved_wounds)
 
-	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds, "error": ""}
+	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
+			"dice_used": needed_dice, "error": ""}
+
+
+## Worst-case dice pool size for a full melee between two units.
+## Attacker strikes + defender counter-strikes, each at 2 dice per attack,
+## across up to MELEE_MAX_BOUTS. Callers should supply at least this many.
+static func _melee_dice_budget(attacker: Types.UnitState, defender: Types.UnitState) -> int:
+	var per_bout = (attacker.model_count * attacker.base_stats.attacks * 2) \
+		+ (defender.model_count * defender.base_stats.attacks * 2)
+	return per_bout * MELEE_MAX_BOUTS
+
+
+## Resolve a melee engagement as bouts (v17 core p.18). Mutates both units
+## in place via wound application. Does NOT apply post-melee panic tokens or
+## trigger retreat — caller handles those so it can integrate with state.
+##
+## Each bout: attacker strikes → defender removes casualties → if defender
+## still alive, defender counter-strikes → attacker removes casualties.
+## Winner = side that dealt more unsaved wounds that bout. Tie → next bout.
+## Hard cap at MELEE_MAX_BOUTS; if still tied at the cap, draw (no retreat).
+##
+## Returns {
+##   bouts: [{atk_hits, atk_saves, atk_wounds, def_hits, def_saves, def_wounds}...],
+##   winner_id, loser_id,  # "" on draw or if one side was already dead
+##   draw: bool,           # true only when cap hit with no winner
+##   dice_used: int,
+##   error: String
+## }
+static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array) -> Dictionary:
+	var summary = {
+		"bouts": [],
+		"winner_id": "",
+		"loser_id": "",
+		"draw": false,
+		"dice_used": 0,
+		"error": "",
+	}
+
+	if attacker.is_dead or target.is_dead:
+		summary["error"] = "Cannot resolve melee: one side already dead"
+		return summary
+
+	var offset: int = 0
+
+	for bout_idx in range(MELEE_MAX_BOUTS):
+		var bout = {
+			"atk_hits": 0, "atk_saves": 0, "atk_wounds": 0,
+			"def_hits": 0, "def_saves": 0, "def_wounds": 0,
+		}
+
+		# Attacker strikes first
+		var atk = _resolve_bout_side(attacker, target, dice_results, offset)
+		if atk["error"] != "":
+			summary["error"] = atk["error"]
+			return summary
+		offset += atk["dice_used"]
+		bout["atk_hits"] = atk["hits"]
+		bout["atk_saves"] = atk["saves"]
+		bout["atk_wounds"] = atk["unsaved_wounds"]
+
+		# Target wiped out before counter-attack
+		if target.is_dead:
+			summary["bouts"].append(bout)
+			summary["winner_id"] = attacker.id
+			summary["loser_id"] = target.id
+			summary["dice_used"] = offset
+			return summary
+
+		# Defender counter-strikes
+		var def = _resolve_bout_side(target, attacker, dice_results, offset)
+		if def["error"] != "":
+			summary["error"] = def["error"]
+			return summary
+		offset += def["dice_used"]
+		bout["def_hits"] = def["hits"]
+		bout["def_saves"] = def["saves"]
+		bout["def_wounds"] = def["unsaved_wounds"]
+		summary["bouts"].append(bout)
+
+		# Attacker wiped out — defender wins the bout trivially
+		if attacker.is_dead:
+			summary["winner_id"] = target.id
+			summary["loser_id"] = attacker.id
+			summary["dice_used"] = offset
+			return summary
+
+		# Both alive — decide the bout
+		if bout["atk_wounds"] > bout["def_wounds"]:
+			summary["winner_id"] = attacker.id
+			summary["loser_id"] = target.id
+			summary["dice_used"] = offset
+			return summary
+		if bout["def_wounds"] > bout["atk_wounds"]:
+			summary["winner_id"] = target.id
+			summary["loser_id"] = attacker.id
+			summary["dice_used"] = offset
+			return summary
+		# Tie → next bout
+
+	# Cap reached with no decisive bout — draw.
+	summary["draw"] = true
+	summary["dice_used"] = offset
+	return summary
 
 
 # =============================================================================

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -297,7 +297,7 @@ func request_action(action_data: Dictionary) -> void:
 			if state.current_order_type == "charge" and not params.get("fizzle", false):
 				params["panic_die"] = _roll_d6()
 				params["fearless_die"] = _roll_d6()
-			var dice = _roll_execute_dice(state)
+			var dice = _roll_execute_dice(state, params)
 			result = GameEngine.execute_order(state, params, dice)
 
 		_:
@@ -353,9 +353,9 @@ func _roll_d6() -> int:
 
 
 ## Helper: Roll the combat dice pool an execute_order requires, sized to the
-## ordered unit and the declared order type. Rolls extras when the target
-## isn't yet known (move_and_shoot may or may not fire after moving).
-func _roll_execute_dice(state: Types.GameState) -> Array:
+## ordered unit and the declared order type. Charge sizing accounts for the
+## full melee: both sides strike per bout, up to GameEngine.MELEE_MAX_BOUTS.
+func _roll_execute_dice(state: Types.GameState, params: Dictionary) -> Array:
 	var unit = _find_unit(state, state.current_order_unit_id)
 	if unit == null:
 		return []
@@ -367,7 +367,15 @@ func _roll_execute_dice(state: Types.GameState) -> Array:
 		"move_and_shoot":
 			num_dice = unit.model_count * 2
 		"charge":
-			num_dice = unit.model_count * unit.base_stats.attacks * 2
+			# Worst case: attacker + defender each strike every bout. Target
+			# may be unknown at roll time (fizzle path) — fall back to a
+			# symmetric pool sized to the attacker.
+			var atk_per_bout = unit.model_count * unit.base_stats.attacks * 2
+			var def_per_bout = atk_per_bout
+			var target = _find_unit(state, params.get("target_id", ""))
+			if target != null:
+				def_per_bout = target.model_count * target.base_stats.attacks * 2
+			num_dice = (atk_per_bout + def_per_bout) * GameEngine.MELEE_MAX_BOUTS
 		"march":
 			num_dice = 0
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -22,6 +22,7 @@ func _init() -> void:
 	_test_execute_charge()
 	_test_panic_test()
 	_test_retreat()
+	_test_melee_bouts()
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
@@ -733,12 +734,19 @@ func _test_panic_test() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
 		var params = {"target_id": state.units[1].id, "panic_die": 5, "fearless_die": 3}
-		# Toff A=2, 1 model → 2 attacks → 4 dice needed (2 inac + 2 vuln)
-		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
+		# Bout 1: attacker Toff (A=2, 1 model) strikes first with 4 dice
+		# [5,5,1,1] → 2 hits, 0 saves, 2 unsaved → Brutes lose 1 model (6→5).
+		# Defender counter-strikes: Brutes A=2 × 5 models = 10 attacks = 20 dice.
+		# [1,1,...] all misses → 0 wounds. Atk=2, def=0 → charger wins bout 1.
+		# Panic post-melee: +1 for both. Brutes had 4 → 5 (test asserts final).
+		var dice = [5, 5, 1, 1]
+		for i in range(20):
+			dice.append(1)
+		var result = GameEngine.execute_order(state, params, dice)
 
 		return (result.success
 			and result.new_state.units[0].x == 14  # charger moved
-			and result.new_state.units[1].panic_tokens == 4  # no extra panic (passed)
+			and result.new_state.units[1].panic_tokens == 5  # +1 post-melee
 			and result.new_state.units[1].model_count < 6)  # melee happened, took casualties
 	)
 
@@ -824,6 +832,151 @@ func _test_retreat() -> void:
 		var result = GameEngine._execute_retreat(state, state.units[2].id)
 		return (result["retreated"]
 			and state.units[2].x != 22 or state.units[2].y != 15)  # didn't land on blocker
+	)
+
+
+func _test_melee_bouts() -> void:
+	print("\n[Test Suite: Melee Bouts]")
+
+	# --- Direct _resolve_melee unit tests ---
+
+	_test("melee: attacker kills defender in bout 1, no counter-attack", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		# Attacker 2 attacks × 2 dice = 4 dice. [5,5,1,1] → 2 hits, 2 unsaved → defender dies.
+		var combat = GameEngine._resolve_melee(atk, def, [5, 5, 1, 1])
+		return (combat["error"] == ""
+			and combat["bouts"].size() == 1
+			and combat["winner_id"] == "atk"
+			and combat["loser_id"] == "def"
+			and not combat["draw"]
+			and combat["dice_used"] == 4
+			and def.is_dead
+			and not atk.is_dead)
+	)
+
+	_test("melee: defender counter-attack kills attacker in bout 1", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		# Attacker [1,1,1,1] → 0 hits. Defender [5,5,1,1] → 2 unsaved → attacker dies.
+		var combat = GameEngine._resolve_melee(atk, def, [1, 1, 1, 1, 5, 5, 1, 1])
+		return (combat["error"] == ""
+			and combat["bouts"].size() == 1
+			and combat["winner_id"] == "def"
+			and combat["loser_id"] == "atk"
+			and atk.is_dead
+			and not def.is_dead)
+	)
+
+	_test("melee: tied bout 1 proceeds to bout 2, decisive there", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		# Bout 1: both whiff (0-0 tie). Bout 2: attacker kills.
+		var dice = [1, 1, 1, 1,   1, 1, 1, 1,   5, 5, 1, 1]
+		var combat = GameEngine._resolve_melee(atk, def, dice)
+		return (combat["error"] == ""
+			and combat["bouts"].size() == 2
+			and combat["winner_id"] == "atk"
+			and combat["loser_id"] == "def"
+			and not combat["draw"]
+			and def.is_dead)
+	)
+
+	_test("melee: bout cap reached with ties ends in draw, no winner", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		# 3 bouts × 2 sides × 4 dice = 24 dice, all whiffs → ties every bout.
+		var dice: Array = []
+		for i in range(24):
+			dice.append(1)
+		var combat = GameEngine._resolve_melee(atk, def, dice)
+		return (combat["error"] == ""
+			and combat["bouts"].size() == GameEngine.MELEE_MAX_BOUTS
+			and combat["draw"]
+			and combat["winner_id"] == ""
+			and combat["loser_id"] == ""
+			and not atk.is_dead
+			and not def.is_dead)
+	)
+
+	_test("melee: rejects if one side already dead", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		def.is_dead = true
+		var combat = GameEngine._resolve_melee(atk, def, [])
+		return combat["error"] != ""
+	)
+
+	_test("melee: errors when dice pool too small", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		# Attacker needs 4 dice, give it 2.
+		var combat = GameEngine._resolve_melee(atk, def, [5, 5])
+		return combat["error"] != "" and "Not enough dice" in combat["error"]
+	)
+
+	# --- Integration via charge path ---
+
+	_test("charge: both participants gain +1 panic after melee ends", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10  # adjacent
+		state.units[0].panic_tokens = 0
+		state.units[1].panic_tokens = 0
+		# Give defender multiple models so melee doesn't end via death.
+		# Replace u1 with 6-model Brutes-like unit (use Toff stats for simplicity).
+		state.units[1].model_count = 6
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [1, 1]).new_state
+
+		# Attacker bout 1: [5,5,1,1] → 2 unsaved → 1 model killed (6→5). Defender counters
+		# with 5×2=10 attacks = 20 dice, all whiff → 0 wounds. Atk=2, def=0 → atk wins bout 1.
+		var dice = [5, 5, 1, 1]
+		for i in range(20):
+			dice.append(1)
+		# Target panic_die=6 + 0 tokens → auto-passes (skipped).
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		return (result.success
+			and result.new_state.units[0].panic_tokens == 1  # attacker +1 post-melee
+			and result.new_state.units[1].panic_tokens == 1  # defender +1 post-melee
+			and not result.new_state.units[0].is_dead
+			and result.new_state.units[1].model_count == 5)
+	)
+
+	_test("charge: charger loses bout → charger retreats, defender holds", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10
+		state.units[0].panic_tokens = 0
+		state.units[1].panic_tokens = 0
+		# Boost charger wounds so it survives the bout and can retreat.
+		state.units[0].base_stats.wounds = 5
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [1, 1]).new_state
+
+		# Charger strikes first with [1,1,1,1] → 0 wounds. Defender counters [5,5,1,1]
+		# → 2 unsaved → charger current_wounds=2 (W=5, still alive). Def wins bout 1.
+		# Charger is the loser → charger retreats.
+		var dice = [1, 1, 1, 1, 5, 5, 1, 1]
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		# Charger moved adjacent to (x=10, y=10 → x=10 target at 11), charge_dest x=10 wait...
+		# _find_adjacent_cell picks nearest adjacent cell to target. Target at (11,10), charger
+		# approaching from (10,10) → adjacent cell (10,10) itself is distance 1 from target. Fine.
+		# After losing: charger retreats 2×(panic_tokens_after_melee=1) = 2 cells away from defender.
+		# Defender at (11,10), charger now at charge_dest.x. Retreat direction = -x.
+		# So final charger x < charge_dest.x.
+		var charger = result.new_state.units[0]
+		return (result.success
+			and not charger.is_dead
+			and charger.panic_tokens == 1  # +1 post-melee
+			and charger.x < 11  # retreated away from defender
+			and not result.new_state.units[1].is_dead
+			and result.new_state.units[1].x == 11  # defender held
+			and result.new_state.units[1].y == 10)
 	)
 
 

--- a/memory/checkpoint-2026-04-22-melee-bouts.md
+++ b/memory/checkpoint-2026-04-22-melee-bouts.md
@@ -1,0 +1,59 @@
+# Checkpoint — 2026-04-22 — Two-sided Melee Bouts (#55)
+
+**Branch:** `feature/melee-bouts` (commits `0f4584c`, `6af7a16`). **Not yet merged.**
+**Closes:** #55 (two-sided melee bouts with counter-attack).
+
+## What shipped
+
+Melee resolves in bouts per v17 core p.18 instead of a single attacker-only pass.
+
+**`_resolve_melee(attacker, target, dice_results) -> Dictionary`:**
+- Per bout: attacker strikes → defender removes casualties → (if defender alive) defender counter-strikes → attacker removes casualties.
+- Winner = side dealing more unsaved wounds that bout. Equal → next bout.
+- Hard cap `MELEE_MAX_BOUTS = 3`; cap-hit draw = no retreat (both sides still panic).
+- Returns `{bouts: [...], winner_id, loser_id, draw, dice_used, error}`.
+
+**Helpers:** `_resolve_bout_side` (one side's strikes, consumes dice from a pool via offset), `_melee_dice_budget` (worst-case sizing, unused externally but available).
+
+**Charge integration (`_execute_charge`):**
+- After melee: +1 panic to both survivors; loser runs `_execute_retreat`.
+- Charger can now lose and retreat — no longer guaranteed to hold the adjacent cell.
+- Action log carries full bout history, winner/loser ids, retreat result, `charger_retreated` flag.
+
+**Server dice pool:** `network_server._roll_execute_dice` now sizes charge pool as `(A_atk + A_def) * 2 * MELEE_MAX_BOUTS`, using the target's stats when available. Fizzle path falls back to a symmetric pool on attacker stats.
+
+**Tests:** 8 new (6 direct `_resolve_melee`, 2 charge integration) + 1 updated (Fearless test now supplies counter-attack dice + expects post-melee panic). 89 engine + 19 type = 108 total, all passing.
+
+**User-reported manual validation:** charging bouts exercised via test-stack clients — works end-to-end.
+
+## Design decisions
+
+- **Bout cap = 3 with draw-on-cap** — rules have no hard cap, but tied bouts on whiffing dice could loop forever. Cap keeps the engine deterministic; draws still apply the post-melee panic. Easy to lift later if playtest finds 3 feels wrong.
+- **Pre-rolled dice pool, not a `roll_d6` Callable** — initially planned to switch to Callable injection (panic/retreat pattern) but the engine's charge path already uses a pool for audit/determinism. Keeping the pool convention; caller sizes it for worst case.
+- **Charger retreats on loss, without re-pathfinding** — `_execute_retreat` anchors off nearest enemy; the defender is adjacent, so charger retreats back away naturally. No special-case code.
+- **Dead target skips its counter-attack** — checked between attacker strike and defender strike. Prevents ghost attacks from a wiped unit.
+
+## Deferred / not addressed
+
+- Return fire on shooting (#40) — sibling problem to #55, still open.
+- Stand-and-shoot (#54) — fires at charger before melee.
+- Two-sided shooting engagements with simultaneous return (#40).
+- Line of sight / closest-target enforcement (#56).
+
+## Board state after
+
+Open issues (suggested sequencing):
+1. **#40** — v17 shooting engagements: simultaneous return fire + winner/loser retreat (natural next, same shape as #55)
+2. **#56** — LoS + closest-target (Euclidean + #55 done, unblocked)
+3. **#54** — Stand and Shoot (small, depends on #40)
+4. **#45–#51, #57** — independent mediums
+5. **#58** — Terrain system (large)
+6. **#59** — Scenario system (large)
+7. **#62** — DT retreat (depends on #58)
+8. **#42** — Cult audit (pre-deploy)
+
+New since last checkpoint: **#64** (Pulumi/DO infra), **#65** (refactor large files), **#66** (beads evaluation), **#67** (roster export), **#68** (copy room code), **#69** (rules viewer exploration), **#70** (UI scaling + art pipeline).
+
+## Next pickup
+
+**#40 (return fire + shooting retreat)** — mirrors #55's bout structure for shooting. Defender returns fire simultaneously, winner/loser determined by unsaved wounds, loser retreats. Can reuse `_execute_retreat` and the post-engagement panic pattern.


### PR DESCRIPTION
## Summary

Melee now resolves in bouts per v17 core p.18 instead of a single attacker-only pass.

- `_resolve_melee` rewritten as a bout loop with alternating attacker/defender strikes, winner decided by unsaved wounds per bout, cap at `MELEE_MAX_BOUTS = 3` with cap-hit draw = no retreat.
- `_execute_charge` applies +1 panic to every survivor post-melee and routes the loser through `_execute_retreat` — the charger can now lose and retreat instead of always holding the adjacent cell.
- `network_server._roll_execute_dice` sizes the charge pool for both sides across the bout cap.
- Action-log entry carries full bout history, winner/loser ids, retreat result.

Closes #55.

## Test plan

- [x] Engine unit tests: 89/89 passing (8 new bout tests + updated Fearless charge test).
- [x] Types tests: 19/19 passing.
- [x] Manual verification via `scripts/test-stack.sh` — charging bouts exercised end-to-end with two clients (user-confirmed).
- [ ] Reviewer: sanity-check the action log shape change (`bouts: [...]`, `melee_winner_id`, `melee_loser_id`, `charger_retreated`) against any client-side consumers.

## Design notes

- **Bout cap of 3** — rules have no hard limit, but tied whiff-dice could loop forever. Draw-on-cap preserves determinism; both sides still get post-melee panic. Easy to tune later.
- **Pre-rolled dice pool** — kept the existing audit/determinism convention instead of switching to `roll_d6: Callable` injection. Caller sizes the pool for worst case.
- **Charger retreat** — `_execute_retreat` anchors off nearest enemy, and the defender is adjacent, so a losing charger naturally retreats backward. No special-case code.

## Deferred (new/related issues)

- #40 return fire on shooting (sibling — same bout-ish shape)
- #54 stand and shoot
- #56 LoS + closest-target

🤖 Generated with [Claude Code](https://claude.com/claude-code)