### PR TITLE
feat(engine): shooting engagements with simultaneous return fire (#40)

### DIFF
--- a/docs/wiki/Manual-Testing-Guide.md
+++ b/docs/wiki/Manual-Testing-Guide.md
@@ -70,10 +70,10 @@ Each round, players alternate picking Snobs to "Make Ready." The sidebar is phas
 
 **order_execute** — run the order
 - Sidebar shows the declared order, blundered state, and movement range with dice bonus applied.
-- **Volley Fire:** click an enemy unit to fire (`-1 Inaccuracy` unless blundered).
+- **Volley Fire:** click an enemy unit to fire (`-1 Inaccuracy` unless blundered). Shooting resolves as a simultaneous engagement (v17 p.13): the target returns fire if it has a ranged weapon, no powder smoke, and the shooter is in range. Casualties from the primary shot do not suppress return fire. Winner (more unsaved wounds) forces the loser to retreat `D6 + 2" × panic tokens`; ties produce no retreat.
 - **March:** click a destination cell within `M + move_bonus`.
 - **Charge:** click an enemy within `M + move_bonus`; attacker auto-pathfinds to an adjacent cell and resolves melee as bouts (v17 p.18) — attacker strikes, defender removes casualties, defender counter-strikes, winner = more unsaved wounds per bout. Tied bouts repeat up to 3×; cap-hit ties draw with no retreat. Post-melee both survivors gain +1 panic; the loser retreats (which can include the charger).
-- **Move & Shoot:** click a destination (max `M`, or `1D6` if blundered), then click an enemy to fire from the new position *or* press **Confirm move (no shot)** to skip the shot.
+- **Move & Shoot:** click a destination (max `M`, or `1D6` if blundered), then click an enemy to fire from the new position *or* press **Confirm move (no shot)** to skip the shot. The engagement rule is the same as Volley Fire — return-fire range is measured from the shooter's post-move position.
 
 On success the turn either passes to the opposing seat (if they still have unordered Snobs), or — once both sides' Snobs are done — transitions to `follower_self_order`.
 
@@ -128,6 +128,7 @@ The fastest way to force each path without an hour-long game:
 | Blunder panic | `+1 panic` in unit info when order blundered | Panic not applied |
 | Charge panic test | Target with panic tokens may fail (D6+tokens ≥ 7). Failed = +1 panic token, target retreats away from charger (D6 + 2" per token), melee skipped. Fearless (Brutes, Fodder 8+) get 3+ override. 0-token targets auto-pass. Board edge retreat = destroyed. | Panic test not logged, target doesn't move on failed test, melee always resolves |
 | Melee bouts | Target passes panic → bout loop runs: attacker strikes, defender removes dead, defender counter-strikes (if alive), attacker removes dead. Winner = more unsaved wounds that bout; tied bouts repeat up to 3 before draw. Both survivors +1 panic after the melee; loser retreats (charger can end up retreating instead of holding the cell). | Only one side rolls, no counter-attack, melee always ends after one pass, charger always holds the cell regardless of outcome |
+| Shooting engagement | Volley Fire / Move & Shoot resolves both sides simultaneously when target is eligible to return fire (has ranged weapon, no powder smoke, shooter in range — measured from post-move position for Move & Shoot). Casualties don't suppress return fire. Winner's loser retreats `D6 + 2"×tokens`; tie = no retreat. Each side gains +1 panic token per side that took hits. | Only shooter rolls, return fire ignored after heavy casualties, smoked unit still returns fire, tied engagement still retreats someone |
 | Move & Shoot two-click | Destination staged → Confirm button appears | Confirm never appears, or first click executes immediately |
 | Round advance | `has_ordered` clears on all units, powder smoke gone | Units stay marked ordered across rounds |
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -511,15 +511,23 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 
 	# Volley Fire gives -1 Inaccuracy bonus (unless blundered)
 	var inaccuracy_mod = -1 if not state.current_order_blundered else 0
+	var retreat_die: int = params.get("retreat_die", 1)
 
 	var new_state = _clone_state(state)
 	var new_unit = _find_unit_in(new_state, unit.id)
 	var new_target = _find_unit_in(new_state, target_id)
 
-	var combat = _resolve_shooting(new_unit, new_target, dice_results, inaccuracy_mod)
+	var combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, inaccuracy_mod)
 	if combat["error"] != "":
 		result.error = combat["error"]
 		return result
+
+	# Loser retreats (v17 core p.15). Tie → no retreat.
+	var retreat: Dictionary = {}
+	if not combat["tie"] and combat["loser_id"] != "":
+		var loser = _find_unit_in(new_state, combat["loser_id"])
+		if loser and not loser.is_dead:
+			retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
 
 	_advance_after_order(new_state)
 
@@ -532,19 +540,45 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 		"target_id": target_id,
 		"target_type": target.unit_type,
 		"blundered": state.current_order_blundered,
-		"hits": combat["hits"],
-		"saves": combat["saves"],
-		"unsaved_wounds": combat["unsaved_wounds"]
+		"hits": combat["att_hits"],
+		"saves": combat["att_saves"],
+		"unsaved_wounds": combat["att_wounds"],
+		"return_fire": combat["return_fire_fired"],
+		"return_hits": combat["def_hits"],
+		"return_saves": combat["def_saves"],
+		"return_wounds": combat["def_wounds"],
+		"engagement_winner_id": combat["winner_id"],
+		"engagement_loser_id": combat["loser_id"],
+		"engagement_tie": combat["tie"],
+		"retreat": retreat,
 	})
 
 	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = dice_results
 	var blunder_text = " (blundered, no bonus)" if state.current_order_blundered else " (-1 Inaccuracy)"
-	result.description = "Volley Fire! %s → %s%s (%d hits, %d saved, %d wounds)%s" % [
+	var return_text = ""
+	if combat["return_fire_fired"]:
+		return_text = " | return fire %d hits, %d wounds" % [combat["def_hits"], combat["def_wounds"]]
+	var outcome = ""
+	if combat["tie"]:
+		outcome = " — tied"
+	elif combat["winner_id"] == new_unit.id:
+		outcome = " — shooter wins"
+		if new_target.is_dead:
+			outcome += " [TARGET DESTROYED]"
+		elif retreat.get("destroyed", false):
+			outcome += " — target fled off board [DESTROYED]"
+	else:
+		outcome = " — target wins"
+		if new_unit.is_dead:
+			outcome += " [SHOOTER DESTROYED]"
+		elif retreat.get("destroyed", false):
+			outcome += " — shooter fled off board [DESTROYED]"
+	result.description = "Volley Fire! %s → %s%s (%d hits, %d wounds)%s%s" % [
 		unit.unit_type, target.unit_type, blunder_text,
-		combat["hits"], combat["saves"], combat["unsaved_wounds"],
-		" [DESTROYED]" if new_target.is_dead else ""
+		combat["att_hits"], combat["att_wounds"],
+		return_text, outcome,
 	]
 
 	return result
@@ -579,8 +613,19 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	new_unit.x = x
 	new_unit.y = y
 
-	# Shoot target (if provided and able)
-	var combat = {"hits": 0, "saves": 0, "unsaved_wounds": 0, "error": ""}
+	# Shoot target (if provided and able). Return-fire eligibility uses the
+	# shooter's post-move position.
+	var retreat_die: int = params.get("retreat_die", 1)
+	var combat: Dictionary = {
+		"att_hits": 0, "att_saves": 0, "att_wounds": 0,
+		"def_hits": 0, "def_saves": 0, "def_wounds": 0,
+		"return_fire_fired": false,
+		"winner_id": "", "loser_id": "",
+		"tie": false,
+		"error": "",
+	}
+	var retreat: Dictionary = {}
+	var fired: bool = false
 	var new_target: Types.UnitState = null
 	if target_id != "":
 		new_target = _find_unit_in(new_state, target_id)
@@ -588,7 +633,15 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 			# Check range from new position
 			var shoot_dist = _grid_distance(x, y, new_target.x, new_target.y)
 			if shoot_dist <= new_unit.base_stats.weapon_range and not new_unit.has_powder_smoke:
-				combat = _resolve_shooting(new_unit, new_target, dice_results, 0)
+				combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, 0)
+				if combat["error"] != "":
+					result.error = combat["error"]
+					return result
+				fired = true
+				if not combat["tie"] and combat["loser_id"] != "":
+					var loser = _find_unit_in(new_state, combat["loser_id"])
+					if loser and not loser.is_dead:
+						retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
 
 	_advance_after_order(new_state)
 
@@ -602,18 +655,29 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 		"to_x": x, "to_y": y,
 		"target_id": target_id,
 		"blundered": state.current_order_blundered,
-		"hits": combat["hits"],
-		"unsaved_wounds": combat["unsaved_wounds"]
+		"fired": fired,
+		"hits": combat["att_hits"],
+		"unsaved_wounds": combat["att_wounds"],
+		"return_fire": combat["return_fire_fired"],
+		"return_hits": combat["def_hits"],
+		"return_wounds": combat["def_wounds"],
+		"engagement_winner_id": combat["winner_id"],
+		"engagement_loser_id": combat["loser_id"],
+		"engagement_tie": combat["tie"],
+		"retreat": retreat,
 	})
 
 	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = dice_results
 	var shoot_text = ""
-	if target_id != "" and combat["hits"] > 0:
+	if fired:
 		shoot_text = " → shot %s (%d hits, %d wounds)" % [
-			new_target.unit_type if new_target else "?", combat["hits"], combat["unsaved_wounds"]
+			new_target.unit_type if new_target else "?",
+			combat["att_hits"], combat["att_wounds"]
 		]
+		if combat["return_fire_fired"]:
+			shoot_text += ", return fire %d wounds" % combat["def_wounds"]
 	result.description = "Move & Shoot! %s to (%d,%d)%s" % [unit.unit_type, x, y, shoot_text]
 
 	return result
@@ -1165,13 +1229,16 @@ static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState
 # COMBAT RESOLUTION HELPERS
 # =============================================================================
 
-## Resolve a shooting engagement. Modifies new_attacker and new_target in place.
-## Returns { hits, saves, unsaved_wounds, error }
-static func _resolve_shooting(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, inaccuracy_mod: int) -> Dictionary:
+## Resolve one side's shooting attacks. Consumes dice from the pool starting
+## at `offset`. Does NOT mutate either unit — caller applies wounds, smoke,
+## and panic tokens after both sides have rolled. Returns
+## { hits, saves, unsaved_wounds, dice_used, error }.
+static func _resolve_shooting_side(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, offset: int, inaccuracy_mod: int) -> Dictionary:
 	var num_attacks = attacker.model_count
 	var needed_dice = num_attacks * 2
-	if dice_results.size() < needed_dice:
-		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "error": "Not enough dice (need %d, got %d)" % [needed_dice, dice_results.size()]}
+	if dice_results.size() - offset < needed_dice:
+		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
+				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
 
 	var inaccuracy = maxi(attacker.base_stats.inaccuracy + inaccuracy_mod, 2)
 	var vulnerability = target.base_stats.vulnerability
@@ -1185,8 +1252,8 @@ static func _resolve_shooting(attacker: Types.UnitState, target: Types.UnitState
 	var unsaved_wounds = 0
 
 	for i in range(num_attacks):
-		var inac_roll = dice_results[i]
-		var vuln_roll = dice_results[num_attacks + i]
+		var inac_roll = dice_results[offset + i]
+		var vuln_roll = dice_results[offset + num_attacks + i]
 		if inac_roll >= inaccuracy:
 			hits += 1
 			if vuln_roll >= vulnerability:
@@ -1194,18 +1261,112 @@ static func _resolve_shooting(attacker: Types.UnitState, target: Types.UnitState
 			else:
 				unsaved_wounds += 1
 
-	# Apply wounds
-	_apply_wounds(target, unsaved_wounds)
+	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
+			"dice_used": needed_dice, "error": ""}
 
-	# Any hit gives target a panic token
-	if hits > 0:
+
+## Is the target eligible to return fire at the shooter? v17 core p.13:
+## target must have a ranged weapon, no powder smoke, and the shooter must
+## be within the target's weapon range. Casualties from the primary strike
+## do NOT suppress return fire (resolved from pre-engagement state).
+static func _can_return_fire(target: Types.UnitState, shooter: Types.UnitState) -> bool:
+	if target.is_dead or shooter.is_dead:
+		return false
+	if target.base_stats.weapon_range <= 0:
+		return false
+	if target.has_powder_smoke:
+		return false
+	var dist := _grid_distance(target.x, target.y, shooter.x, shooter.y)
+	return dist <= target.base_stats.weapon_range
+
+
+## Resolve a shooting engagement (v17 core p.13). Both sides roll against
+## pre-engagement model counts — casualties from the primary strike do not
+## suppress return fire. Wounds, smoke, and hit-panic tokens applied after
+## both sides have rolled.
+##
+## Winner = side that dealt more unsaved wounds. Tie = no winner, no retreat
+## (caller still runs _execute_retreat only when winner/loser set).
+##
+## Returns {
+##   att_hits, att_saves, att_wounds,
+##   def_hits, def_saves, def_wounds,
+##   return_fire_fired: bool,
+##   winner_id, loser_id,           # "" on tie
+##   tie: bool,
+##   dice_used: int,
+##   error: String
+## }
+static func _resolve_shooting_engagement(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, attacker_inaccuracy_mod: int) -> Dictionary:
+	var result = {
+		"att_hits": 0, "att_saves": 0, "att_wounds": 0,
+		"def_hits": 0, "def_saves": 0, "def_wounds": 0,
+		"return_fire_fired": false,
+		"winner_id": "", "loser_id": "",
+		"tie": false,
+		"dice_used": 0,
+		"error": "",
+	}
+
+	if attacker.is_dead or target.is_dead:
+		result["error"] = "Cannot resolve shooting: one side already dead"
+		return result
+
+	# Attacker rolls first (dice pool laid out attacker-then-defender).
+	var att = _resolve_shooting_side(attacker, target, dice_results, 0, attacker_inaccuracy_mod)
+	if att["error"] != "":
+		result["error"] = att["error"]
+		return result
+	result["att_hits"] = att["hits"]
+	result["att_saves"] = att["saves"]
+	result["att_wounds"] = att["unsaved_wounds"]
+
+	var offset: int = att["dice_used"]
+
+	# Return fire eligibility checked from pre-engagement state.
+	var can_return = _can_return_fire(target, attacker)
+	if can_return:
+		# Defender return fire — inaccuracy_mod=0 (no volley-fire bonus on return).
+		var defn = _resolve_shooting_side(target, attacker, dice_results, offset, 0)
+		if defn["error"] != "":
+			result["error"] = defn["error"]
+			return result
+		result["def_hits"] = defn["hits"]
+		result["def_saves"] = defn["saves"]
+		result["def_wounds"] = defn["unsaved_wounds"]
+		result["return_fire_fired"] = true
+		offset += defn["dice_used"]
+
+	result["dice_used"] = offset
+
+	# Apply wounds simultaneously (casualties don't suppress return fire).
+	_apply_wounds(target, result["att_wounds"])
+	if result["return_fire_fired"]:
+		_apply_wounds(attacker, result["def_wounds"])
+
+	# Panic tokens from taking hits (any hits, saved or not).
+	if result["att_hits"] > 0 and not target.is_dead:
 		target.panic_tokens = mini(target.panic_tokens + 1, 6)
+	if result["def_hits"] > 0 and not attacker.is_dead:
+		attacker.panic_tokens = mini(attacker.panic_tokens + 1, 6)
 
-	# Black powder gives powder smoke
+	# Powder smoke: whichever side fired with black_powder gets a smoke token.
 	if attacker.equipment == "black_powder":
 		attacker.has_powder_smoke = true
+	if result["return_fire_fired"] and target.equipment == "black_powder":
+		target.has_powder_smoke = true
 
-	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds, "error": ""}
+	# Winner / loser / tie — decided by total unsaved wounds dealt.
+	if result["att_wounds"] > result["def_wounds"]:
+		result["winner_id"] = attacker.id
+		result["loser_id"] = target.id
+	elif result["def_wounds"] > result["att_wounds"]:
+		result["winner_id"] = target.id
+		result["loser_id"] = attacker.id
+	else:
+		result["tie"] = true
+
+	return result
 
 
 ## Resolve one side's attacks in a melee bout. Consumes dice from the pool

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -293,10 +293,13 @@ func request_action(action_data: Dictionary) -> void:
 
 		"execute_order":
 			var params = action_data.get("params", {})
-			# Charge: server rolls panic test + fearless dice for the target.
+			# Charge: server rolls panic test + fearless + retreat dice for the target.
 			if state.current_order_type == "charge" and not params.get("fizzle", false):
 				params["panic_die"] = _roll_d6()
 				params["fearless_die"] = _roll_d6()
+				params["retreat_die"] = _roll_d6()
+			# Shooting engagements can also trigger a retreat (v17 p.15).
+			if state.current_order_type in ["volley_fire", "move_and_shoot"]:
 				params["retreat_die"] = _roll_d6()
 			var dice = _roll_execute_dice(state, params)
 			result = GameEngine.execute_order(state, params, dice)
@@ -363,10 +366,15 @@ func _roll_execute_dice(state: Types.GameState, params: Dictionary) -> Array:
 
 	var num_dice = 0
 	match state.current_order_type:
-		"volley_fire":
-			num_dice = unit.model_count * 2
-		"move_and_shoot":
-			num_dice = unit.model_count * 2
+		"volley_fire", "move_and_shoot":
+			# Shooting engagement: both sides may fire. Target dice added when
+			# the target is known; otherwise over-roll with a symmetric pool.
+			var att_dice = unit.model_count * 2
+			var def_dice = att_dice
+			var s_target = _find_unit(state, params.get("target_id", ""))
+			if s_target != null:
+				def_dice = s_target.model_count * 2
+			num_dice = att_dice + def_dice
 		"charge":
 			# Worst case: attacker + defender each strike every bout. Target
 			# may be unknown at roll time (fizzle path) — fall back to a

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -23,6 +23,7 @@ func _init() -> void:
 	_test_panic_test()
 	_test_retreat()
 	_test_melee_bouts()
+	_test_shooting_engagements()
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
@@ -294,8 +295,9 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		# Toff I=5, -1 bonus → needs 4+. Target V=5, W=2.
-		# Die 4 hits (4>=4), die 1 fails save → 1 wound.
-		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 1])
+		# Die 4 hits, die 1 fails save → 1 wound. Target returns fire with 2 dice,
+		# both whiff → 0 shooter wounds.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 1, 1, 1])
 
 		return result.success and result.new_state.units[1].current_wounds == 1
 	)
@@ -306,7 +308,8 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		# Die 4 hits with -1 bonus (base I=5 would have missed). Die 6 saves V=5.
-		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6])
+		# Return fire: 2 dice of 1 → miss, no shooter wounds.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6, 1, 1])
 
 		return result.success and result.new_state.units[1].current_wounds == 0  # saved
 	)
@@ -322,7 +325,8 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[2].id, "volley_fire", 1, [3, 3]).new_state
 
 		# Fodder I=6. Blundered: no -1, so needs 6+. Die 5 misses.
-		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 1])
+		# Return fire from Toff u1: 2 dice → 1s miss.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 1, 1, 1])
 
 		return result.success and result.new_state.units[1].current_wounds == 0
 	)
@@ -333,7 +337,8 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
-		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [3, 1])
+		# Shooter miss (3 at I4+), return fire 2 dice of 1 → miss.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [3, 1, 1, 1])
 
 		return result.success and result.new_state.units[0].has_powder_smoke
 	)
@@ -344,7 +349,8 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		# Die 4 hits (I4+ with bonus), die 6 saves. Hit → panic token even if saved.
-		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6])
+		# Return fire: 2 dice of 1 → miss (no extra panic flow).
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6, 1, 1])
 
 		return result.success and result.new_state.units[1].panic_tokens == 1
 	)
@@ -398,7 +404,9 @@ func _test_execute_volley_fire() -> void:
 
 		# Fodder I=6, bonus -1 → 5+. All 4 hit, all 4 fail save → 4 wounds.
 		# Target is Toff W=2, model_count=1 → dies after 2 wounds.
-		var dice = [5, 5, 5, 5, 1, 1, 1, 1]
+		# Target had 1 model pre-engagement → returns fire with 2 dice (casualties
+		# don't suppress return fire per v17 p.13). Both miss.
+		var dice = [5, 5, 5, 5, 1, 1, 1, 1, 1, 1]
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, dice)
 
 		return result.success and result.new_state.units[1].is_dead
@@ -415,8 +423,9 @@ func _test_execute_move_and_shoot() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "move_and_shoot", 3, [3, 3]).new_state
 
 		# After move, distance 8 ≤ 18. Toff I=5, no bonus → 5+. Die 5 hits. Die 1 wounds.
+		# Return fire: 2 dice of 1 → miss.
 		var params = {"x": 12, "y": 15, "target_id": state.units[1].id}
-		var result = GameEngine.execute_order(state, params, [5, 1])
+		var result = GameEngine.execute_order(state, params, [5, 1, 1, 1])
 
 		return (result.success
 			and result.new_state.units[0].x == 12
@@ -989,6 +998,214 @@ func _test_melee_bouts() -> void:
 			and not result.new_state.units[1].is_dead
 			and result.new_state.units[1].x == 11  # defender held
 			and result.new_state.units[1].y == 10)
+	)
+
+
+func _test_shooting_engagements() -> void:
+	print("\n[Test Suite: Shooting Engagements]")
+
+	# --- Direct _resolve_shooting_engagement tests ---
+
+	_test("engagement: return fire fires when target in range with weapon", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10  # within 18
+		# Attacker [5,1] hits + wounds (I5+, V5). Defender [5,1] same.
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1, 5, 1], 0)
+		return (combat["error"] == ""
+			and combat["return_fire_fired"]
+			and combat["att_hits"] == 1 and combat["att_wounds"] == 1
+			and combat["def_hits"] == 1 and combat["def_wounds"] == 1
+			and combat["tie"]
+			and combat["winner_id"] == "" and combat["loser_id"] == "")
+	)
+
+	_test("engagement: powder smoke on target blocks return fire", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10
+		dfn.has_powder_smoke = true
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		return (combat["error"] == ""
+			and not combat["return_fire_fired"]
+			and combat["att_wounds"] == 1
+			and combat["def_wounds"] == 0
+			and combat["winner_id"] == "atk"
+			and combat["loser_id"] == "dfn")
+	)
+
+	_test("engagement: target out of own range cannot return fire", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		# Defender wr=4 but attacker 10 cells away → out of range for return.
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 4, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 20; dfn.y = 10
+		atk.base_stats.weapon_range = 18
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		return (combat["error"] == ""
+			and not combat["return_fire_fired"]
+			and combat["winner_id"] == "atk")
+	)
+
+	_test("engagement: melee-only target (wr=0) cannot return fire", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Brutes", "infantry", 6, 2, 5, 2, 5, 0, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 12; dfn.y = 10
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		return combat["error"] == "" and not combat["return_fire_fired"]
+	)
+
+	_test("engagement: casualties do not suppress return fire", func():
+		# Multi-model defender losing a model pre-return still returns fire with
+		# pre-engagement model count. Attacker 4 models vs Defender 3 models.
+		var atk = _mock_unit("atk", 1, "Atk", "infantry", 6, 1, 5, 1, 5, 18, 4)
+		var dfn = _mock_unit("dfn", 2, "Dfn", "infantry", 6, 1, 5, 1, 5, 18, 3)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10
+		# Attacker 4 shots × 2 dice = 8. All hit+wound → 4 unsaved → dfn has 1 model left.
+		# Defender return fire rolled from 3-model state = 6 dice — casualties
+		# should not reduce the pool.
+		var dice = [5, 5, 5, 5, 1, 1, 1, 1,   # attacker 4 hits, 4 wounds
+					5, 5, 5, 1, 1, 1]          # defender 3 hits (I5+), 3 wounds
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, dice, 0)
+		return (combat["error"] == ""
+			and combat["return_fire_fired"]
+			and combat["att_hits"] == 4 and combat["att_wounds"] == 4
+			and combat["def_hits"] == 3 and combat["def_wounds"] == 3
+			and combat["dice_used"] == 14
+			# Dfn had 3 models, took 4 wounds → 3 models dead → is_dead.
+			and dfn.is_dead
+			# Atk 4 models W=1 took 3 wounds → 3 models dead, 1 survives.
+			and atk.model_count == 1)
+	)
+
+	_test("engagement: attacker wins and defender becomes loser", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1, 1, 1], 0)
+		return (combat["error"] == ""
+			and combat["winner_id"] == "atk"
+			and combat["loser_id"] == "dfn"
+			and not combat["tie"])
+	)
+
+	_test("engagement: defender wins and attacker becomes loser", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [1, 1, 5, 1], 0)
+		return (combat["error"] == ""
+			and combat["winner_id"] == "dfn"
+			and combat["loser_id"] == "atk"
+			and not combat["tie"])
+	)
+
+	_test("engagement: both whiff → no winner, no loser", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		atk.x = 10; atk.y = 10
+		dfn.x = 15; dfn.y = 10
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [1, 1, 1, 1], 0)
+		return (combat["error"] == ""
+			and combat["tie"]
+			and combat["winner_id"] == "" and combat["loser_id"] == "")
+	)
+
+	_test("engagement: rejects when one side already dead", func():
+		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		dfn.is_dead = true
+		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [], 0)
+		return combat["error"] != ""
+	)
+
+	# --- volley_fire integration ---
+
+	_test("volley_fire: loser retreats after engagement", func():
+		var state = _mock_orders_state_ranged()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Attacker hits+wounds, defender whiffs → atk wins, dfn retreats.
+		var params = {"target_id": state.units[1].id, "retreat_die": 2}
+		var result = GameEngine.execute_order(state, params, [4, 1, 1, 1])
+
+		# Defender had 0 panic tokens, got hit → +1 panic. Retreat distance = 2 + 2*1 = 4.
+		# Defender at (20,15), attacker at (10,15), retreat +X → (24,15).
+		return (result.success
+			and result.new_state.units[1].panic_tokens == 1
+			and result.new_state.units[1].x == 24
+			and result.new_state.units[1].y == 15)
+	)
+
+	_test("volley_fire: tied engagement → no retreat", func():
+		var state = _mock_orders_state_ranged()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Both hit+wound (4 with -1 bonus hits for atk, 5 hits for dfn at I5). Tie 1-1.
+		var params = {"target_id": state.units[1].id, "retreat_die": 3}
+		var result = GameEngine.execute_order(state, params, [4, 1, 5, 1])
+
+		# Neither retreats; both still at original positions.
+		return (result.success
+			and result.new_state.units[0].x == 10 and result.new_state.units[0].y == 15
+			and result.new_state.units[1].x == 20 and result.new_state.units[1].y == 15
+			and result.new_state.units[0].current_wounds == 1
+			and result.new_state.units[1].current_wounds == 1)
+	)
+
+	_test("volley_fire: target killed outright still returned fire pre-death", func():
+		var state = _mock_orders_state_ranged()
+		# Give attacker enough shots to kill Toff target (W=2) in one engagement.
+		state.units[0].model_count = 2  # 2 shots per engagement
+		state.units[0].max_models = 2
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Attacker 2 shots, both hit+wound → dfn W=2, dies. Defender pre-engagement
+		# count was 1 → returns fire with 2 dice.
+		var params = {"target_id": state.units[1].id, "retreat_die": 1}
+		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1, 5, 1])
+
+		# Attacker took 1 wound from return fire; defender dead.
+		return (result.success
+			and result.new_state.units[1].is_dead
+			and result.new_state.units[0].current_wounds == 1)
+	)
+
+	# --- move_and_shoot integration ---
+
+	_test("move_and_shoot: return fire uses shooter's post-move position", func():
+		var state = _mock_orders_state_ranged()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[0].base_stats.weapon_range = 18
+		state.units[1].x = 22; state.units[1].y = 15
+		state.units[1].base_stats.weapon_range = 10  # pre-move distance 12 > 10
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "move_and_shoot", 3, [3, 3]).new_state
+
+		# Attacker moves to (14,15) → distance 8 ≤ 10 → defender can return fire.
+		var params = {"x": 14, "y": 15, "target_id": state.units[1].id, "retreat_die": 1}
+		var result = GameEngine.execute_order(state, params, [5, 1, 5, 1])
+
+		# Both hit+wound → tie, no retreat. Confirms return fire measured from (14,15).
+		return (result.success
+			and result.new_state.units[0].x == 14
+			and result.new_state.units[0].current_wounds == 1
+			and result.new_state.units[1].current_wounds == 1)
 	)
 
 

--- a/memory/checkpoint-2026-04-22-shooting-engagements.md
+++ b/memory/checkpoint-2026-04-22-shooting-engagements.md
@@ -1,0 +1,65 @@
+# Checkpoint — 2026-04-22 — Shooting Engagements (#40)
+
+**Branch:** `feature/shooting-engagements` (commits `082fc9f`, `2e4c7e7`). **Not yet merged.**
+**Closes:** #40 (simultaneous return fire + winner/loser retreat).
+
+## What shipped
+
+Shooting resolves as a two-sided engagement per v17 core pp. 13, 15, 20.
+
+**`_resolve_shooting_engagement(attacker, target, dice, att_inac_mod) -> Dictionary`:**
+- Attacker rolls first (pool laid out attacker-then-defender).
+- Defender returns fire if eligible — computed from pre-engagement model counts.
+- Wounds applied to both sides AFTER both rolls (casualties don't suppress return).
+- Hit-triggered panic tokens (per side), powder smoke on whichever side fired with `black_powder`.
+- Winner = more unsaved wounds. Tie = no winner, no retreat.
+- Returns `{att/def_hits/saves/wounds, return_fire_fired, winner_id, loser_id, tie, dice_used, error}`.
+
+**Helpers:**
+- `_resolve_shooting_side(attacker, target, dice, offset, inac_mod)` — the old `_resolve_shooting` refactored to pure computation with dice offset, no mutation.
+- `_can_return_fire(target, shooter)` — alive + `weapon_range > 0` + no smoke + shooter in target's range.
+
+**Caller integration:**
+- `_execute_volley_fire` + `_execute_move_and_shoot` now route through the engagement resolver, retreat the loser via `_execute_retreat(..., retreat_die)`.
+- Move & Shoot return-fire range uses shooter's **post-move** position.
+- Action log gains `return_fire`, `return_hits`, `return_wounds`, `engagement_winner_id/loser_id/tie`, `retreat`.
+
+**Server:**
+- Rolls `retreat_die` for `volley_fire` / `move_and_shoot` alongside the existing charge roll.
+- Dice pool sizing: `(shooter.models + target.models) × 2` when target known, symmetric pool otherwise (fizzle / no-target move_and_shoot branches).
+
+**Tests:** 13 new shooting engagement tests (9 direct resolver + 4 integration), 7 existing shooting tests updated to pad for return-fire dice. 103 engine + 19 type = 122 total, all passing.
+
+## Design decisions
+
+- **Per-hit panic only** — v17 shooting rules don't call for an "all participants gain +1 panic" like melee p.18 does. Only hit-triggered tokens accrue (both sides independently, based on whether the opposite side landed a hit).
+- **Smoke applies after resolution** — so return fire can still happen when the attacker is a black_powder unit (attacker's smoke token lands at the end of the engagement, not before target checks).
+- **Return fire inaccuracy_mod = 0** — volley fire's `-1` bonus is only for the declared order, not the return fire response.
+- **Dice laid out attacker-then-defender** — simple offset scheme, matches melee bout layout.
+- **Move & Shoot no-target path unchanged** — when shooter just moves (no target_id), `fired` stays false, no engagement, legacy behavior preserved.
+
+## Not addressed here (deferred)
+
+- **DT tests on retreat through Followers** (#62) — gated on terrain system (#58).
+- **Powder-smoke UI indicator** — filed as new issue **#74**.
+- **v18 off-board retreat rule** — tracked under #72.
+- **Stand-and-shoot** (#54) — defender fires before melee on a charge. Separate mechanic.
+
+## Board state after
+
+Major v17 combat mechanics now complete: panic (#52 → #61), retreat (#53 → #63) with D6+2×tokens (fix in #73), melee bouts (#55 → #71), shooting engagements (#40 → this PR). Phase 4 combat engine is close to rules-complete.
+
+New issues this session: #64, #65, #66, #67, #68, #69, #70 (feature/refactor tracking), #72 (ruleset agility audit), #74 (powder smoke UI).
+
+Still open for Phase 4 rules accuracy:
+- **#56** LoS + closest-target (unblocked)
+- **#54** Stand and Shoot
+- **#45–#51, #57** independent mediums
+- **#58** terrain (large)
+- **#59** scenarios (large)
+- **#42** cult audit
+- **#38** remaining v17 rules-accuracy audit items
+
+## Next pickup
+
+**#56 (LoS + closest-target)** is a natural follow-up — constrains who can be shot at, tightens the targeting that now gets exercised by return fire too. Small-to-medium scope.


### PR DESCRIPTION
## Summary

Shooting now resolves as a two-sided engagement per v17 core pp. 13, 15, 20. Both sides fire simultaneously against pre-engagement model counts; casualties from the primary strike do not suppress return fire. Winner forces loser to retreat; ties produce no retreat.

- Split \`_resolve_shooting\` into \`_resolve_shooting_side\` (pure compute, dice offset, no mutation) + new \`_resolve_shooting_engagement\` (both sides then apply wounds/smoke/panic).
- \`_can_return_fire\` gates defender response: alive, \`weapon_range > 0\`, no powder smoke, shooter in target's range.
- \`_execute_volley_fire\` and \`_execute_move_and_shoot\` route through the engagement resolver and retreat the loser. Move & Shoot measures return-fire range from the shooter's **post-move** position.
- \`network_server\` rolls \`retreat_die\` for shooting orders and sizes the dice pool for both sides.
- Action log gains \`return_fire\`, \`return_hits\`, \`return_wounds\`, \`engagement_winner_id / loser_id / tie\`, \`retreat\`.

Closes #40.

## Test plan

- [x] Engine tests: 103/103 passing (13 new for shooting engagements, 7 existing shooting tests padded for the return-fire dice pool).
- [x] Types tests: 19/19 passing.
- [ ] Reviewer: exercise with \`scripts/test-stack.sh\` and check (a) return fire fires when expected, (b) powder smoke blocks return fire, (c) losing shooter retreats using D6 + 2×tokens, (d) action log shows \`return_fire\` / \`engagement_winner_id\` / \`retreat\`.

## Design decisions

- **Per-hit panic only** — melee p.18 grants +1 to all participants post-engagement; v17 shooting rules don't call for that, so only hit-triggered tokens accrue per side.
- **Smoke applied post-engagement** — shooter's smoke token lands after the resolver checks return-fire eligibility, so a firing black_powder shooter still takes return fire the same turn (next turn it can't fire). Target's smoke (if they also fired with black_powder on return) gets applied the same way.
- **Return fire gets no volley-fire bonus** — \`inaccuracy_mod = 0\` for the response, regardless of the declared order.
- **Dice layout** — attacker-then-defender, matches melee bout convention.

## Explicitly not in this PR

- **Stand-and-shoot** (#54) — defender fires at charger before melee. Different mechanic; separate issue.
- **DT tests for retreat through Followers** (#62) — gated on terrain system #58.
- **Powder smoke UI indicator** — filed as new issue #74.
- **v18 off-board retreat rule** — tracked under #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)