### PR TITLE
feat(engine): line of sight + closest-target enforcement (#56)

### DIFF
--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -496,17 +496,11 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 	if not target:
 		result.error = "Target not found"
 		return result
-	if target.is_dead:
-		result.error = "Target is dead"
-		return result
-	if target.owner_seat == unit.owner_seat:
-		result.error = "Cannot target your own units"
-		return result
 
-	# Range check
-	var distance = _grid_distance(unit.x, unit.y, target.x, target.y)
-	if distance > unit.base_stats.weapon_range:
-		result.error = "Target out of range (max %d)" % unit.base_stats.weapon_range
+	# LoS + range + closest-target validation
+	var target_error = _is_valid_shooting_target(state, unit, target)
+	if target_error != "":
+		result.error = target_error
 		return result
 
 	# Volley Fire gives -1 Inaccuracy bonus (unless blundered)
@@ -630,9 +624,9 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	if target_id != "":
 		new_target = _find_unit_in(new_state, target_id)
 		if new_target and not new_target.is_dead and new_target.owner_seat != unit.owner_seat:
-			# Check range from new position
-			var shoot_dist = _grid_distance(x, y, new_target.x, new_target.y)
-			if shoot_dist <= new_unit.base_stats.weapon_range and not new_unit.has_powder_smoke:
+			# Validate from post-move position: range + LoS + closest-target
+			var shoot_error = _is_valid_shooting_target_from(new_state, new_unit, new_target, x, y)
+			if shoot_error == "" and not new_unit.has_powder_smoke:
 				combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, 0)
 				if combat["error"] != "":
 					result.error = combat["error"]
@@ -762,6 +756,11 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 	if target.owner_seat == unit.owner_seat:
 		result.error = "Cannot charge your own units"
+		return result
+
+	# LoS check (v17 p.16: must have LoS to charge target)
+	if not _has_line_of_sight(state, unit.x, unit.y, target.x, target.y):
+		result.error = "No line of sight to charge target"
 		return result
 
 	# Charge range: M + move_bonus. Must end adjacent (distance = 1) to target.
@@ -1578,6 +1577,177 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 
 
 # =============================================================================
+# LINE OF SIGHT + TARGETING
+# =============================================================================
+
+## Supercover line-of-sight check between two grid cells.
+## Returns true if no alive non-Snob unit (except the two endpoints) occupies
+## any cell the line passes through. Snobs never block LoS (v17 p.5).
+## Both endpoints are excluded from the blocker check.
+static func _has_line_of_sight(state: Types.GameState, from_x: int, from_y: int, to_x: int, to_y: int) -> bool:
+	# Build a set of occupied cells that block LoS (alive non-Snob Followers).
+	# Exclude the two endpoint cells.
+	var blockers: Dictionary = {}  # "x,y" -> true
+	for u in state.units:
+		if u.is_dead or u.is_snob():
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		if (u.x == from_x and u.y == from_y) or (u.x == to_x and u.y == to_y):
+			continue
+		blockers["%d,%d" % [u.x, u.y]] = true
+
+	if blockers.is_empty():
+		return true
+
+	# Supercover line walk: enumerate every cell the line from center of
+	# (from_x, from_y) to center of (to_x, to_y) touches or crosses.
+	var dx: int = to_x - from_x
+	var dy: int = to_y - from_y
+	var sx: int = 1 if dx > 0 else (-1 if dx < 0 else 0)
+	var sy: int = 1 if dy > 0 else (-1 if dy < 0 else 0)
+	var adx: int = abs(dx)
+	var ady: int = abs(dy)
+
+	var cx: int = from_x
+	var cy: int = from_y
+
+	# Use a modified Bresenham for supercover (checks diagonal-adjacent cells).
+	# error tracks which axis to step. When error triggers both, step diag and
+	# also check the two axis-only neighbors for coverage.
+	var error: int = adx - ady
+
+	var steps: int = adx + ady
+	for _i in range(steps):
+		var e2: int = 2 * error
+		if e2 > -ady and e2 < adx:
+			# Diagonal step — supercover: check both axis-adjacent cells too
+			if blockers.has("%d,%d" % [cx + sx, cy]):
+				return false
+			if blockers.has("%d,%d" % [cx, cy + sy]):
+				return false
+			cx += sx
+			cy += sy
+			error += -ady + adx
+		elif e2 > -ady:
+			cx += sx
+			error -= ady
+		else:
+			cy += sy
+			error += adx
+
+		# Skip endpoint
+		if cx == to_x and cy == to_y:
+			break
+		if blockers.has("%d,%d" % [cx, cy]):
+			return false
+
+	return true
+
+
+## Find all valid shooting targets for a unit: alive enemies in weapon range
+## with line of sight.
+static func _find_shooting_targets(state: Types.GameState, shooter: Types.UnitState) -> Array:
+	var targets: Array = []
+	var wr: int = shooter.base_stats.weapon_range
+	if wr <= 0:
+		return targets
+	for u in state.units:
+		if u.is_dead or u.owner_seat == shooter.owner_seat:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		var d := _grid_distance(shooter.x, shooter.y, u.x, u.y)
+		if d <= wr and _has_line_of_sight(state, shooter.x, shooter.y, u.x, u.y):
+			targets.append(u)
+	return targets
+
+
+## Find shooting targets from an arbitrary position (for move_and_shoot post-move).
+static func _find_shooting_targets_from(state: Types.GameState, shooter: Types.UnitState, from_x: int, from_y: int) -> Array:
+	var targets: Array = []
+	var wr: int = shooter.base_stats.weapon_range
+	if wr <= 0:
+		return targets
+	for u in state.units:
+		if u.is_dead or u.owner_seat == shooter.owner_seat:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		var d := _grid_distance(from_x, from_y, u.x, u.y)
+		if d <= wr and _has_line_of_sight(state, from_x, from_y, u.x, u.y):
+			targets.append(u)
+	return targets
+
+
+## Validate whether a specific target is legal for shooting.
+## Returns empty string if valid, error string if not.
+## Enforces closest-target rule (v17 p.12): must target the closest valid
+## enemy in range + LoS (ties are permissive — any tied target is legal).
+## Sharpshooters bypass the closest-target restriction but still need LoS.
+static func _is_valid_shooting_target(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState) -> String:
+	if target.is_dead:
+		return "Target is dead"
+	if target.owner_seat == shooter.owner_seat:
+		return "Cannot target your own units"
+
+	var distance := _grid_distance(shooter.x, shooter.y, target.x, target.y)
+	if distance > shooter.base_stats.weapon_range:
+		return "Target out of range (max %d)" % shooter.base_stats.weapon_range
+
+	if not _has_line_of_sight(state, shooter.x, shooter.y, target.x, target.y):
+		return "No line of sight to target"
+
+	# Closest-target enforcement (skip for Sharpshooters)
+	if "sharpshooters" not in shooter.special_rules:
+		var valid_targets := _find_shooting_targets(state, shooter)
+		if valid_targets.is_empty():
+			return "No valid targets in range with LoS"
+		# Find the minimum distance among valid targets
+		var min_dist: float = 99999.0
+		for vt in valid_targets:
+			var vd := _grid_distance(shooter.x, shooter.y, vt.x, vt.y)
+			if vd < min_dist:
+				min_dist = vd
+		# Target must be among the closest (ties allowed)
+		if distance > min_dist + 0.01:  # small epsilon for float comparison
+			return "Must target closest enemy (closest is at %.1f, target is at %.1f)" % [min_dist, distance]
+
+	return ""
+
+
+## Same as _is_valid_shooting_target but checks LoS from an arbitrary position
+## (for move_and_shoot post-move validation).
+static func _is_valid_shooting_target_from(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState, from_x: int, from_y: int) -> String:
+	if target.is_dead:
+		return "Target is dead"
+	if target.owner_seat == shooter.owner_seat:
+		return "Cannot target your own units"
+
+	var distance := _grid_distance(from_x, from_y, target.x, target.y)
+	if distance > shooter.base_stats.weapon_range:
+		return "Target out of range (max %d)" % shooter.base_stats.weapon_range
+
+	if not _has_line_of_sight(state, from_x, from_y, target.x, target.y):
+		return "No line of sight to target"
+
+	# Closest-target enforcement (skip for Sharpshooters)
+	if "sharpshooters" not in shooter.special_rules:
+		var valid_targets := _find_shooting_targets_from(state, shooter, from_x, from_y)
+		if valid_targets.is_empty():
+			return "No valid targets in range with LoS"
+		var min_dist: float = 99999.0
+		for vt in valid_targets:
+			var vd := _grid_distance(from_x, from_y, vt.x, vt.y)
+			if vd < min_dist:
+				min_dist = vd
+		if distance > min_dist + 0.01:
+			return "Must target closest enemy (closest is at %.1f, target is at %.1f)" % [min_dist, distance]
+
+	return ""
+
+
+# =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
 
@@ -1626,19 +1796,10 @@ static func _has_unordered_snobs(state: Types.GameState, seat: int) -> bool:
 
 ## Does at least one alive enemy unit sit inside the shooter's weapon range?
 static func _has_valid_volley_target(state: Types.GameState, unit: Types.UnitState) -> bool:
-	var wr: int = unit.base_stats.weapon_range
-	if wr <= 0:
-		return false
-	for u in state.units:
-		if u.is_dead or u.owner_seat == unit.owner_seat:
-			continue
-		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
-		if d <= wr:
-			return true
-	return false
+	return not _find_shooting_targets(state, unit).is_empty()
 
 
-## Does at least one alive enemy unit sit inside the charger's M + move_bonus range?
+## Does at least one alive enemy unit sit inside the charger's M + move_bonus range with LoS?
 static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitState) -> bool:
 	var reach: int = unit.base_stats.movement + state.current_order_move_bonus
 	if reach <= 0:
@@ -1647,7 +1808,7 @@ static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitSta
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
 		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
-		if d <= reach:
+		if d <= reach and _has_line_of_sight(state, unit.x, unit.y, u.x, u.y):
 			return true
 	return false
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -24,6 +24,7 @@ func _init() -> void:
 	_test_retreat()
 	_test_melee_bouts()
 	_test_shooting_engagements()
+	_test_line_of_sight()
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
@@ -385,6 +386,8 @@ func _test_execute_volley_fire() -> void:
 		# Place enemy diagonally: dx=12, dy=12. Euclidean = sqrt(288) ≈ 16.97 ≤ 18.
 		# Manhattan would be 24 > 18 → out of range. Proves Euclidean works.
 		state.units[1].x = 22; state.units[1].y = 27
+		# Remove other enemy so u1 is the closest (closest-target rule).
+		state.units[3].is_dead = true
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
@@ -1206,6 +1209,150 @@ func _test_shooting_engagements() -> void:
 			and result.new_state.units[0].x == 14
 			and result.new_state.units[0].current_wounds == 1
 			and result.new_state.units[1].current_wounds == 1)
+	)
+
+
+func _test_line_of_sight() -> void:
+	print("\n[Test Suite: Line of Sight + Closest Target]")
+
+	_test("LoS: clear line between two units passes", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		# No blockers between them
+		state.units[2].x = 5; state.units[2].y = 5  # out of the way
+		state.units[3].x = 30; state.units[3].y = 5  # out of the way
+		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+	)
+
+	_test("LoS: Follower unit on the line blocks", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		# Place a Follower directly between them
+		state.units[2].x = 15; state.units[2].y = 15
+		return not GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+	)
+
+	_test("LoS: Snob on the line does NOT block", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		# Place the enemy Snob (u1) on the line — Snobs never block LoS.
+		# Create a separate target behind the Snob.
+		state.units[1].x = 15; state.units[1].y = 15  # Snob in the middle
+		state.units[3].x = 20; state.units[3].y = 15  # Follower as actual target
+		# LoS from u0 to u3 should pass — u1 (Snob) doesn't block.
+		state.units[2].x = 5; state.units[2].y = 5  # out of the way
+		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+	)
+
+	_test("LoS: dead unit on the line does NOT block", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 20; state.units[1].y = 15
+		state.units[2].x = 15; state.units[2].y = 15  # Follower in the way
+		state.units[2].is_dead = true  # but dead
+		state.units[3].x = 30; state.units[3].y = 5
+		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+	)
+
+	_test("LoS: endpoints are excluded from blocker check", func():
+		var state = _mock_orders_state()
+		# Both shooter and target are Followers at endpoints — they shouldn't block themselves.
+		state.units[2].x = 10; state.units[2].y = 15
+		state.units[3].x = 20; state.units[3].y = 15
+		state.units[0].x = 5; state.units[0].y = 5
+		state.units[1].x = 30; state.units[1].y = 5
+		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+	)
+
+	_test("LoS: diagonal line blocked by unit on the path", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 16; state.units[1].y = 16
+		# Place blocker at (13,13) — on the diagonal line
+		state.units[2].x = 13; state.units[2].y = 13
+		state.units[3].x = 30; state.units[3].y = 5
+		return not GameEngine._has_line_of_sight(state, 10, 10, 16, 16)
+	)
+
+	_test("closest-target: reject non-closest enemy", func():
+		var state = _mock_orders_state_ranged()
+		# u0 at (10,15), u1 (enemy Snob) at (20,15) dist=10.
+		# Place u3 (enemy Follower) closer at (14,17) dist≈4.5. Off-axis so no LoS block.
+		state.units[3].x = 14; state.units[3].y = 17
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Try to target u1 (farther) instead of u3 (closer) — should be rejected.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1])
+		return not result.success and "closest" in result.error
+	)
+
+	_test("closest-target: tied-closest both legal", func():
+		var state = _mock_orders_state_ranged()
+		# u0 at (10,15). Place both enemies equidistant, neither blocking LoS to the other.
+		state.units[1].x = 20; state.units[1].y = 15  # dist=10
+		state.units[3].x = 10; state.units[3].y = 25  # dist=10
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Both should be valid — provide enough dice for engagement (atk + return fire)
+		var r1 = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1, 1, 1])
+		# Reset state for second attempt
+		state = _mock_orders_state_ranged()
+		state.units[1].x = 20; state.units[1].y = 15
+		state.units[3].x = 10; state.units[3].y = 25
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+		var r2 = GameEngine.execute_order(state, {"target_id": state.units[3].id}, [6, 1, 1, 1])
+
+		return r1.success and r2.success
+	)
+
+	_test("closest-target: Sharpshooters bypass restriction", func():
+		var state = _mock_orders_state_ranged()
+		# Make u0 a Sharpshooter (Chaff)
+		state.units[0].special_rules = ["sharpshooters"] as Array[String]
+		# u3 closer and off-axis so it doesn't block LoS to u1.
+		state.units[3].x = 14; state.units[3].y = 17
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		# Target u1 (farther) — should succeed for Sharpshooters. Enough dice for engagement.
+		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1, 1, 1])
+		return result.success
+	)
+
+	_test("volley_fire: LoS blocked = fizzle succeeds", func():
+		var state = _mock_orders_state_ranged()
+		# Place blocker between shooter and all enemies
+		state.units[2].x = 15; state.units[2].y = 15  # blocks LoS to u1 at (20,15)
+		state.units[3].x = 15; state.units[3].y = 16  # blocks LoS diagonally too
+		# Actually need to make sure NO enemy has LoS. u1 at (20,15) blocked by u2 at (15,15).
+		# u3 at (15,16) is a friendly unit, won't be targeted. Need to check u1 only.
+		# u1 is the only enemy in range. u2 blocks LoS to u1.
+		state.units[3].x = 40; state.units[3].y = 2  # move enemy far away and out of range
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
+
+		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
+		return result.success
+	)
+
+	_test("charge: LoS required to target", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 20; state.units[1].y = 10
+		# Place Follower blocker between charger and target
+		state.units[2].x = 15; state.units[2].y = 10
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [6, 6]).new_state
+
+		var params = {"target_id": state.units[1].id, "panic_die": 1, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
+		return not result.success and "line of sight" in result.error
 	)
 
 


### PR DESCRIPTION
## Summary

- **Line of sight**: supercover line walk — alive Followers block, Snobs never block (v17 p.5), endpoints excluded, dead units don't block
- **Closest-target**: must target the closest valid enemy in range + LoS. Tied distances are permissive. Sharpshooters (Chaff) bypass closest-target but still need LoS.
- Wired into volley fire, move & shoot (LoS from post-move position), charge (LoS required, no closest-target), and fizzle gates

Closes #56.

## Deferred

- Terrain LoS blocking (#58)
- Client-side LoS hints in grid_draw.gd (server remains authoritative; green target rings may show enemies behind blockers but clicks will fail)

## Files changed

| File | What |
|------|------|
| `game_engine.gd` | 6 new functions: `_has_line_of_sight`, `_find_shooting_targets`, `_find_shooting_targets_from`, `_is_valid_shooting_target`, `_is_valid_shooting_target_from`; wired into volley fire, M&S, charge, fizzle gates |
| `test_game_engine.gd` | 11 new tests: LoS clear/blocked/Snob/dead/endpoints/diagonal, closest-target reject/tied/Sharpshooters, fizzle with blocked LoS, charge LoS |

## Test plan

- [x] 114 engine tests pass (11 new LoS/targeting tests)
- [x] 19 type/ruleset tests pass
- [ ] Visual: solo stack — volley fire against target behind another unit should fail
- [ ] Visual: charge against target behind blocker should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)