### PR TITLE
refactor(engine): split game_engine.gd into 5 game/ modules (#65)

### DIFF
--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -5,6 +5,7 @@ extends Control
 ## redeclare them here. Use Board.BOARD_WIDTH etc.
 
 const Board = preload("res://game/board.gd")
+const Targeting = preload("res://game/targeting.gd")
 
 # Scene nodes
 var board_container: Control
@@ -732,7 +733,7 @@ func _render_order_execute_panel() -> void:
 
 	match order_type:
 		"volley_fire":
-			if unit and not _has_valid_enemy_in_range(unit, unit.base_stats.weapon_range):
+			if unit and not _has_valid_shooting_target(unit):
 				order_execute_instruction.text = "No enemies in range — the volley fizzles."
 				order_execute_confirm_button.text = "Continue (no effect)"
 				order_execute_confirm_button.visible = true
@@ -835,18 +836,26 @@ func _on_execute_confirm_pressed() -> void:
 	_send_execute_order({"x": pending_move_x, "y": pending_move_y})
 
 
+## True if any alive enemy is within Euclidean `reach` of `unit`. No LoS
+## check — used for charge fizzle detection (charge ignores LoS in v17).
+## For shooting fizzle, use `_has_valid_shooting_target` so closest-target
+## + LoS rules match the server.
 func _has_valid_enemy_in_range(unit: Types.UnitState, reach: int) -> bool:
 	if reach <= 0:
 		return false
-	var r_sq: float = float(reach * reach)
 	for u in current_game_state.units:
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
-		var dx: int = u.x - unit.x
-		var dy: int = u.y - unit.y
-		if float(dx * dx + dy * dy) <= r_sq:
+		if Board.grid_distance(unit.x, unit.y, u.x, u.y) <= reach:
 			return true
 	return false
+
+
+## True if `shooter` has any legal shooting target right now (in range AND
+## with LoS). Delegates to the shared Targeting module so client and server
+## cannot diverge on what counts as a valid target.
+func _has_valid_shooting_target(shooter: Types.UnitState) -> bool:
+	return not Targeting.find_shooting_targets(current_game_state, shooter).is_empty()
 
 
 # =============================================================================
@@ -863,13 +872,10 @@ func _declare_valid_targets() -> Array:
 	# Snob can always self-order
 	results.append(snob)
 	var cmd_range = snob.get_command_range()
-	var cr_sq: float = float(cmd_range * cmd_range)
 	for unit in current_game_state.units:
 		if (unit.owner_seat == my_seat and not unit.is_snob()
 				and not unit.is_dead and not unit.has_ordered):
-			var dx: int = unit.x - snob.x
-			var dy: int = unit.y - snob.y
-			if float(dx * dx + dy * dy) <= cr_sq:
+			if Board.grid_distance(snob.x, snob.y, unit.x, unit.y) <= cmd_range:
 				results.append(unit)
 	return results
 

--- a/godot/client/scenes/battle.gd
+++ b/godot/client/scenes/battle.gd
@@ -1,14 +1,10 @@
 extends Control
 ## Battle — main gameplay view, unit placement, combat resolution.
+##
+## Board geometry and deployment zones live in game/board.gd — never
+## redeclare them here. Use Board.BOARD_WIDTH etc.
 
-const BOARD_WIDTH = 48
-const BOARD_HEIGHT = 32
-
-# Deployment zones
-const DEPLOY_1_Y_MIN = 28
-const DEPLOY_1_Y_MAX = 31
-const DEPLOY_2_Y_MIN = 0
-const DEPLOY_2_Y_MAX = 3
+const Board = preload("res://game/board.gd")
 
 # Scene nodes
 var board_container: Control
@@ -330,8 +326,8 @@ func _recompute_cell_size() -> void:
 	if avail.x <= 0 or avail.y <= 0:
 		return
 	# Fit board into available space, maintaining aspect ratio
-	var cs_x = avail.x / BOARD_WIDTH
-	var cs_y = avail.y / BOARD_HEIGHT
+	var cs_x = avail.x / Board.BOARD_WIDTH
+	var cs_y = avail.y / Board.BOARD_HEIGHT
 	cell_size = min(cs_x, cs_y)
 
 
@@ -536,7 +532,7 @@ func _input(event: InputEvent) -> void:
 		var local_pos = board_container.get_local_mouse_position()
 		var grid = pixel_to_grid(local_pos.x, local_pos.y)
 
-		if grid.x < 0 or grid.x >= BOARD_WIDTH or grid.y < 0 or grid.y >= BOARD_HEIGHT:
+		if not Board.is_in_bounds(grid.x, grid.y):
 			return
 
 		if current_game_state.phase == "placement":

--- a/godot/client/scenes/grid_draw.gd
+++ b/godot/client/scenes/grid_draw.gd
@@ -2,6 +2,7 @@ extends Control
 ## Draws the game board grid, deployment zones, and cell highlights.
 
 const Board = preload("res://game/board.gd")
+const Targeting = preload("res://game/targeting.gd")
 
 var battle_ref = null  # Reference to battle.gd for cell_size and state
 
@@ -152,7 +153,7 @@ func _draw_order_execute_overlay(state, cs: float, bw: int, bh: int) -> void:
 		"volley_fire":
 			var reach = unit.base_stats.weapon_range
 			_draw_range_circle(unit.x, unit.y, reach, cs, bw, bh, shoot_fill, shoot_outline)
-			target_cells = _enemy_cells_within(unit.x, unit.y, reach, unit.owner_seat)
+			target_cells = _shooting_target_cells(state, unit, unit.x, unit.y)
 		"march":
 			var reach = unit.base_stats.movement + move_bonus
 			_draw_range_circle(unit.x, unit.y, reach, cs, bw, bh, move_fill, move_outline)
@@ -175,7 +176,7 @@ func _draw_order_execute_overlay(state, cs: float, bw: int, bh: int) -> void:
 				# Shoot reach from the staged cell
 				var reach = unit.base_stats.weapon_range
 				_draw_range_circle(px, py, reach, cs, bw, bh, shoot_fill, shoot_outline)
-				target_cells = _enemy_cells_within(px, py, reach, unit.owner_seat)
+				target_cells = _shooting_target_cells(state, unit, px, py)
 				# Mark the staged cell itself
 				draw_rect(Rect2(px * cs, py * cs, cs, cs), Color(1.0, 1.0, 0.4, 0.25))
 				draw_rect(Rect2(px * cs, py * cs, cs, cs), Color(1.0, 1.0, 0.4, 0.9), false, 2.0)
@@ -191,7 +192,8 @@ func _draw_order_execute_overlay(state, cs: float, bw: int, bh: int) -> void:
 
 
 ## Return cell coords of alive enemies within Euclidean distance `reach` of
-## (cx, cy). Empty when reach <= 0.
+## (cx, cy). Empty when reach <= 0. Used for charge target hints — charge
+## ignores LoS in v17 so a pure distance check is correct here.
 func _enemy_cells_within(cx: int, cy: int, reach: int, own_seat: int) -> Array:
 	var out: Array = []
 	if reach <= 0:
@@ -199,14 +201,26 @@ func _enemy_cells_within(cx: int, cy: int, reach: int, own_seat: int) -> Array:
 	var state = battle_ref.current_game_state
 	if not state:
 		return out
-	var r_sq: float = float(reach * reach)
 	for u in state.units:
 		if u.is_dead or u.owner_seat == own_seat:
 			continue
 		if u.x < 0 or u.y < 0:
 			continue
-		var dx: int = u.x - cx
-		var dy: int = u.y - cy
-		if float(dx * dx + dy * dy) <= r_sq:
+		if Board.grid_distance(cx, cy, u.x, u.y) <= reach:
 			out.append(Vector2i(u.x, u.y))
+	return out
+
+
+## Cells of legal shooting targets for `shooter` firing from (fx, fy).
+## Delegates to the shared Targeting module so green target rings always
+## match what the server would accept (LoS, range, dead/own filters).
+## Closest-target restriction is NOT applied here — Sharpshooters and the
+## "any-of-tied-closest" rule make showing all-in-range cells the most
+## informative hint; the order-validation step still blocks illegal picks.
+func _shooting_target_cells(state, shooter, fx: int, fy: int) -> Array:
+	var out: Array = []
+	if not state or not shooter:
+		return out
+	for u in Targeting.find_shooting_targets_from(state, shooter, fx, fy):
+		out.append(Vector2i(u.x, u.y))
 	return out

--- a/godot/client/scenes/grid_draw.gd
+++ b/godot/client/scenes/grid_draw.gd
@@ -1,6 +1,8 @@
 extends Control
 ## Draws the game board grid, deployment zones, and cell highlights.
 
+const Board = preload("res://game/board.gd")
+
 var battle_ref = null  # Reference to battle.gd for cell_size and state
 
 
@@ -12,8 +14,8 @@ func _draw() -> void:
 	if cs <= 0:
 		return
 
-	var bw = battle_ref.BOARD_WIDTH
-	var bh = battle_ref.BOARD_HEIGHT
+	var bw = Board.BOARD_WIDTH
+	var bh = Board.BOARD_HEIGHT
 
 	# Board background
 	draw_rect(Rect2(0, 0, bw * cs, bh * cs), Color(0.12, 0.12, 0.16))
@@ -21,12 +23,12 @@ func _draw() -> void:
 	# Deployment zones
 	# Seat 1 (bottom) — blue tint
 	draw_rect(
-		Rect2(0, battle_ref.DEPLOY_1_Y_MIN * cs, bw * cs, (battle_ref.DEPLOY_1_Y_MAX - battle_ref.DEPLOY_1_Y_MIN + 1) * cs),
+		Rect2(0, Board.DEPLOYMENT_ZONE_1_Y_MIN * cs, bw * cs, (Board.DEPLOYMENT_ZONE_1_Y_MAX - Board.DEPLOYMENT_ZONE_1_Y_MIN + 1) * cs),
 		Color(0.15, 0.2, 0.35, 0.5)
 	)
 	# Seat 2 (top) — red tint
 	draw_rect(
-		Rect2(0, battle_ref.DEPLOY_2_Y_MIN * cs, bw * cs, (battle_ref.DEPLOY_2_Y_MAX - battle_ref.DEPLOY_2_Y_MIN + 1) * cs),
+		Rect2(0, Board.DEPLOYMENT_ZONE_2_Y_MIN * cs, bw * cs, (Board.DEPLOYMENT_ZONE_2_Y_MAX - Board.DEPLOYMENT_ZONE_2_Y_MIN + 1) * cs),
 		Color(0.35, 0.15, 0.15, 0.5)
 	)
 
@@ -41,8 +43,8 @@ func _draw() -> void:
 	var font = ThemeDB.fallback_font
 	if font:
 		var font_size = clampi(int(cs * 0.8), 10, 20)
-		draw_string(font, Vector2(4, battle_ref.DEPLOY_2_Y_MAX * cs + cs * 0.8), "P2 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(1, 0.6, 0.6, 0.6))
-		draw_string(font, Vector2(4, battle_ref.DEPLOY_1_Y_MIN * cs + cs * 0.8), "P1 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0.6, 0.6, 1.0, 0.6))
+		draw_string(font, Vector2(4, Board.DEPLOYMENT_ZONE_2_Y_MAX * cs + cs * 0.8), "P2 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(1, 0.6, 0.6, 0.6))
+		draw_string(font, Vector2(4, Board.DEPLOYMENT_ZONE_1_Y_MIN * cs + cs * 0.8), "P1 Deploy", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color(0.6, 0.6, 1.0, 0.6))
 
 	var state = battle_ref.current_game_state
 

--- a/godot/game/board.gd
+++ b/godot/game/board.gd
@@ -1,0 +1,47 @@
+class_name Board
+extends RefCounted
+## Board geometry and movement validation.
+##
+## Pure RefCounted — no Node, no scene tree, no signals. Imported by both
+## the server engine and the client renderer so deployment-zone bounds and
+## distance math cannot drift between authoritative and presentation code.
+##
+## 1 cell = 1 inch. Distance is Euclidean (sqrt(dx² + dy²)) so diagonal
+## ranges are geometrically correct; range visualizations are circles.
+
+const BOARD_WIDTH: int = 48
+const BOARD_HEIGHT: int = 32
+
+# Deployment zones (4 rows each)
+const DEPLOYMENT_ZONE_1_Y_MIN: int = 28  # Bottom (seat 1)
+const DEPLOYMENT_ZONE_1_Y_MAX: int = 31
+const DEPLOYMENT_ZONE_2_Y_MIN: int = 0   # Top (seat 2)
+const DEPLOYMENT_ZONE_2_Y_MAX: int = 3
+
+
+## Euclidean distance between two grid cells.
+static func grid_distance(x1: int, y1: int, x2: int, y2: int) -> float:
+	var dx: int = x2 - x1
+	var dy: int = y2 - y1
+	return sqrt(float(dx * dx + dy * dy))
+
+
+## True if (x, y) is inside the board.
+static func is_in_bounds(x: int, y: int) -> bool:
+	return x >= 0 and x < BOARD_WIDTH and y >= 0 and y < BOARD_HEIGHT
+
+
+## Validate that `unit` may end its move on (x, y). Returns "" on success,
+## else a human-readable error string. Checks bounds, occupancy by other
+## live units, and the v17 rule that a unit may move across an objective
+## but not finish a move on top of one (v17 core p.22).
+static func validate_move(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> String:
+	if not is_in_bounds(x, y):
+		return "Coordinates out of bounds"
+	for u in state.units:
+		if not u.is_dead and u.x == x and u.y == y and u.id != unit.id:
+			return "Position occupied"
+	for obj in state.objectives:
+		if obj.x == x and obj.y == y:
+			return "Cannot end move on an objective marker"
+	return ""

--- a/godot/game/combat.gd
+++ b/godot/game/combat.gd
@@ -1,0 +1,319 @@
+class_name Combat
+extends RefCounted
+## Shooting and melee resolution.
+##
+## Pure RefCounted — no Node, no signals, no scene tree. Dice rolls are
+## passed in as a flat Array[int] so the caller (engine or test) controls
+## the RNG. Wound application and panic-token bookkeeping mutate the
+## supplied UnitState refs in place; range/LoS validation is the caller's
+## job (handled in game/targeting.gd).
+##
+## V17 model:
+##   - Shooting engagement: attacker rolls, then defender rolls return fire
+##     against pre-engagement model counts (casualties do NOT suppress
+##     return fire — v17 core p.13). Wounds applied simultaneously.
+##   - Melee bout: attacker strikes, defender removes casualties; if
+##     defender survives, defender counter-strikes. Winner = more unsaved
+##     wounds in the bout. Tie = next bout. Hard cap MELEE_MAX_BOUTS = 3
+##     bouts to prevent dice-whiff infinite loops; cap-tie ends in a draw
+##     (no retreat, but caller still applies +1 panic per melee-ended).
+
+const Board = preload("res://game/board.gd")
+
+# Melee bout cap — v17 has no hard limit, but tied bouts could loop forever
+# on whiffing dice. Cap at 3; unresolved ties after the cap end in a draw
+# with no retreat (caller still applies +1 panic per melee-ended rule).
+const MELEE_MAX_BOUTS: int = 3
+
+
+## Apply wounds to a unit, removing models as they die. Mutates `unit`.
+static func apply_wounds(unit: Types.UnitState, wounds: int) -> void:
+	var remaining_wounds = wounds
+	while remaining_wounds > 0 and not unit.is_dead:
+		unit.current_wounds += 1
+		remaining_wounds -= 1
+		if unit.current_wounds >= unit.base_stats.wounds:
+			unit.model_count -= 1
+			unit.current_wounds = 0
+			if unit.model_count <= 0:
+				unit.is_dead = true
+				unit.model_count = 0
+
+
+## Resolve one side's shooting attacks. Consumes dice from the pool starting
+## at `offset`. Does NOT mutate either unit — caller applies wounds, smoke,
+## and panic tokens after both sides have rolled.
+## Returns { hits, saves, unsaved_wounds, dice_used, error }.
+static func resolve_shooting_side(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, offset: int, inaccuracy_mod: int) -> Dictionary:
+	var num_attacks = attacker.model_count
+	var needed_dice = num_attacks * 2
+	if dice_results.size() - offset < needed_dice:
+		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
+				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
+
+	var inaccuracy = maxi(attacker.base_stats.inaccuracy + inaccuracy_mod, 2)
+	var vulnerability = target.base_stats.vulnerability
+
+	# Equipment modifiers
+	if attacker.equipment == "missile":
+		vulnerability = maxi(vulnerability - 2, 2)
+
+	var hits = 0
+	var saves = 0
+	var unsaved_wounds = 0
+
+	for i in range(num_attacks):
+		var inac_roll = dice_results[offset + i]
+		var vuln_roll = dice_results[offset + num_attacks + i]
+		if inac_roll >= inaccuracy:
+			hits += 1
+			if vuln_roll >= vulnerability:
+				saves += 1
+			else:
+				unsaved_wounds += 1
+
+	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
+			"dice_used": needed_dice, "error": ""}
+
+
+## Is the target eligible to return fire at the shooter? v17 core p.13:
+## target must have a ranged weapon, no powder smoke, and the shooter must
+## be within the target's weapon range. Casualties from the primary strike
+## do NOT suppress return fire (resolved from pre-engagement state).
+static func can_return_fire(target: Types.UnitState, shooter: Types.UnitState) -> bool:
+	if target.is_dead or shooter.is_dead:
+		return false
+	if target.base_stats.weapon_range <= 0:
+		return false
+	if target.has_powder_smoke:
+		return false
+	return Board.grid_distance(target.x, target.y, shooter.x, shooter.y) <= target.base_stats.weapon_range
+
+
+## Resolve a shooting engagement (v17 core p.13). Both sides roll against
+## pre-engagement model counts — casualties from the primary strike do not
+## suppress return fire. Wounds, smoke, and hit-panic tokens applied after
+## both sides have rolled.
+##
+## Winner = side that dealt more unsaved wounds. Tie = no winner, no retreat
+## (caller still runs retreat only when winner/loser set).
+##
+## Returns {
+##   att_hits, att_saves, att_wounds,
+##   def_hits, def_saves, def_wounds,
+##   return_fire_fired: bool,
+##   winner_id, loser_id,           # "" on tie
+##   tie: bool,
+##   dice_used: int,
+##   error: String
+## }
+static func resolve_shooting_engagement(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, attacker_inaccuracy_mod: int) -> Dictionary:
+	var result = {
+		"att_hits": 0, "att_saves": 0, "att_wounds": 0,
+		"def_hits": 0, "def_saves": 0, "def_wounds": 0,
+		"return_fire_fired": false,
+		"winner_id": "", "loser_id": "",
+		"tie": false,
+		"dice_used": 0,
+		"error": "",
+	}
+
+	if attacker.is_dead or target.is_dead:
+		result["error"] = "Cannot resolve shooting: one side already dead"
+		return result
+
+	# Attacker rolls first (dice pool laid out attacker-then-defender).
+	var att = resolve_shooting_side(attacker, target, dice_results, 0, attacker_inaccuracy_mod)
+	if att["error"] != "":
+		result["error"] = att["error"]
+		return result
+	result["att_hits"] = att["hits"]
+	result["att_saves"] = att["saves"]
+	result["att_wounds"] = att["unsaved_wounds"]
+
+	var offset: int = att["dice_used"]
+
+	# Return fire eligibility checked from pre-engagement state.
+	var can_return = can_return_fire(target, attacker)
+	if can_return:
+		# Defender return fire — inaccuracy_mod=0 (no volley-fire bonus on return).
+		var defn = resolve_shooting_side(target, attacker, dice_results, offset, 0)
+		if defn["error"] != "":
+			result["error"] = defn["error"]
+			return result
+		result["def_hits"] = defn["hits"]
+		result["def_saves"] = defn["saves"]
+		result["def_wounds"] = defn["unsaved_wounds"]
+		result["return_fire_fired"] = true
+		offset += defn["dice_used"]
+
+	result["dice_used"] = offset
+
+	# Apply wounds simultaneously (casualties don't suppress return fire).
+	apply_wounds(target, result["att_wounds"])
+	if result["return_fire_fired"]:
+		apply_wounds(attacker, result["def_wounds"])
+
+	# Panic tokens from taking hits (any hits, saved or not).
+	if result["att_hits"] > 0 and not target.is_dead:
+		target.panic_tokens = mini(target.panic_tokens + 1, 6)
+	if result["def_hits"] > 0 and not attacker.is_dead:
+		attacker.panic_tokens = mini(attacker.panic_tokens + 1, 6)
+
+	# Powder smoke: whichever side fired with black_powder gets a smoke token.
+	if attacker.equipment == "black_powder":
+		attacker.has_powder_smoke = true
+	if result["return_fire_fired"] and target.equipment == "black_powder":
+		target.has_powder_smoke = true
+
+	# Winner / loser / tie — decided by total unsaved wounds dealt.
+	if result["att_wounds"] > result["def_wounds"]:
+		result["winner_id"] = attacker.id
+		result["loser_id"] = target.id
+	elif result["def_wounds"] > result["att_wounds"]:
+		result["winner_id"] = target.id
+		result["loser_id"] = attacker.id
+	else:
+		result["tie"] = true
+
+	return result
+
+
+## Resolve one side's attacks in a melee bout. Consumes dice from the pool
+## starting at `offset`. Returns { hits, saves, unsaved_wounds, dice_used, error }.
+## Mutates `defender` via apply_wounds.
+static func resolve_bout_side(attacker: Types.UnitState, defender: Types.UnitState, dice_results: Array, offset: int) -> Dictionary:
+	var attacks_per_model = attacker.base_stats.attacks
+	var inaccuracy = attacker.base_stats.inaccuracy
+	var vulnerability = defender.base_stats.vulnerability
+
+	# Close combat equipment reduces inaccuracy by 1 (min 2)
+	if attacker.equipment == "close_combat":
+		inaccuracy = maxi(inaccuracy - 1, 2)
+
+	var num_attacks = attacker.model_count * attacks_per_model
+	var needed_dice = num_attacks * 2
+	if dice_results.size() - offset < needed_dice:
+		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
+				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
+
+	var hits = 0
+	var saves = 0
+	var unsaved_wounds = 0
+
+	for i in range(num_attacks):
+		var inac_roll = dice_results[offset + i]
+		var vuln_roll = dice_results[offset + num_attacks + i]
+		if inac_roll >= inaccuracy:
+			hits += 1
+			if vuln_roll >= vulnerability:
+				saves += 1
+			else:
+				unsaved_wounds += 1
+
+	apply_wounds(defender, unsaved_wounds)
+
+	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
+			"dice_used": needed_dice, "error": ""}
+
+
+## Worst-case dice pool size for a full melee between two units.
+## Attacker strikes + defender counter-strikes, each at 2 dice per attack,
+## across up to MELEE_MAX_BOUTS. Callers should supply at least this many.
+static func melee_dice_budget(attacker: Types.UnitState, defender: Types.UnitState) -> int:
+	var per_bout = (attacker.model_count * attacker.base_stats.attacks * 2) \
+		+ (defender.model_count * defender.base_stats.attacks * 2)
+	return per_bout * MELEE_MAX_BOUTS
+
+
+## Resolve a melee engagement as bouts (v17 core p.18). Mutates both units
+## in place via wound application. Does NOT apply post-melee panic tokens or
+## trigger retreat — caller handles those so it can integrate with state.
+##
+## Each bout: attacker strikes → defender removes casualties → if defender
+## still alive, defender counter-strikes → attacker removes casualties.
+## Winner = side that dealt more unsaved wounds that bout. Tie → next bout.
+## Hard cap at MELEE_MAX_BOUTS; if still tied at the cap, draw (no retreat).
+##
+## Returns {
+##   bouts: [{atk_hits, atk_saves, atk_wounds, def_hits, def_saves, def_wounds}...],
+##   winner_id, loser_id,  # "" on draw or if one side was already dead
+##   draw: bool,           # true only when cap hit with no winner
+##   dice_used: int,
+##   error: String
+## }
+static func resolve_melee(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array) -> Dictionary:
+	var summary = {
+		"bouts": [],
+		"winner_id": "",
+		"loser_id": "",
+		"draw": false,
+		"dice_used": 0,
+		"error": "",
+	}
+
+	if attacker.is_dead or target.is_dead:
+		summary["error"] = "Cannot resolve melee: one side already dead"
+		return summary
+
+	var offset: int = 0
+
+	for bout_idx in range(MELEE_MAX_BOUTS):
+		var bout = {
+			"atk_hits": 0, "atk_saves": 0, "atk_wounds": 0,
+			"def_hits": 0, "def_saves": 0, "def_wounds": 0,
+		}
+
+		# Attacker strikes first
+		var atk = resolve_bout_side(attacker, target, dice_results, offset)
+		if atk["error"] != "":
+			summary["error"] = atk["error"]
+			return summary
+		offset += atk["dice_used"]
+		bout["atk_hits"] = atk["hits"]
+		bout["atk_saves"] = atk["saves"]
+		bout["atk_wounds"] = atk["unsaved_wounds"]
+
+		# Target wiped out before counter-attack
+		if target.is_dead:
+			summary["bouts"].append(bout)
+			summary["winner_id"] = attacker.id
+			summary["loser_id"] = target.id
+			summary["dice_used"] = offset
+			return summary
+
+		# Defender counter-strikes
+		var def = resolve_bout_side(target, attacker, dice_results, offset)
+		if def["error"] != "":
+			summary["error"] = def["error"]
+			return summary
+		offset += def["dice_used"]
+		bout["def_hits"] = def["hits"]
+		bout["def_saves"] = def["saves"]
+		bout["def_wounds"] = def["unsaved_wounds"]
+		summary["bouts"].append(bout)
+
+		# Attacker wiped out — defender wins the bout trivially
+		if attacker.is_dead:
+			summary["winner_id"] = target.id
+			summary["loser_id"] = attacker.id
+			summary["dice_used"] = offset
+			return summary
+
+		# Both alive — decide the bout
+		if bout["atk_wounds"] > bout["def_wounds"]:
+			summary["winner_id"] = attacker.id
+			summary["loser_id"] = target.id
+			summary["dice_used"] = offset
+			return summary
+		if bout["def_wounds"] > bout["atk_wounds"]:
+			summary["winner_id"] = target.id
+			summary["loser_id"] = attacker.id
+			summary["dice_used"] = offset
+			return summary
+		# Tie → next bout
+
+	# Cap reached with no decisive bout — draw.
+	summary["draw"] = true
+	summary["dice_used"] = offset
+	return summary

--- a/godot/game/objectives.gd
+++ b/godot/game/objectives.gd
@@ -1,0 +1,133 @@
+class_name Objectives
+extends RefCounted
+## Objective marker capture and end-of-game victory determination.
+##
+## Pure RefCounted, no node deps. Imported by the engine to recompute
+## capture state after any positional change and to declare a winner
+## once the round limit is reached or one side is wiped out.
+##
+## V17 model:
+##   - Only Followers capture (Snobs never do — v17 core p.22).
+##   - "Within 1"" = Euclidean distance ≤ 1.0, so only orthogonal neighbors.
+##     Diagonal cells (√2 ≈ 1.41) are out of range and do NOT capture.
+##   - Both seats adjacent → contested → captured_by = 0.
+##   - Only one seat adjacent → captured by that seat.
+##   - Neither adjacent → retain prior captured_by.
+##   - Units cannot end a move on an objective cell (enforced in board.gd).
+##
+## Victory order:
+##   1. One side has zero alive units and the other has any → that side wins.
+##   2. Headless Chicken — one side has zero alive Snobs → instant loss.
+##   3. Round limit reached → most-controlled-objectives wins, ties = draw.
+##   4. Otherwise no winner yet.
+##
+## Solo mode (one side has zero units total) skips victory entirely.
+
+const Board = preload("res://game/board.gd")
+
+
+## Is there an objective marker at this cell?
+static func is_objective_at(state: Types.GameState, x: int, y: int) -> bool:
+	for obj in state.objectives:
+		if obj.x == x and obj.y == y:
+			return true
+	return false
+
+
+## Recompute capture state for every objective per v17 core p.22.
+## Called after any state change that could shift Follower positions
+## (placement finalized, moves, charges, unit deaths). Mutates in place.
+##
+## MVP simplification: the v17 "only one objective captured per move"
+## player-choice rule is not enforced here — a move that ends adjacent to
+## two uncontrolled objectives will capture both. Tracked for a follow-up
+## when objective placement is dense enough to matter in practice.
+static func resolve_objective_captures(state: Types.GameState) -> void:
+	for obj in state.objectives:
+		var seat1_adjacent := 0
+		var seat2_adjacent := 0
+		for u in state.units:
+			if u.is_dead or u.is_snob():
+				continue
+			if u.x < 0 or u.y < 0:
+				continue
+			var d := Board.grid_distance(u.x, u.y, obj.x, obj.y)
+			if d <= 1.0:
+				if u.owner_seat == 1:
+					seat1_adjacent += 1
+				else:
+					seat2_adjacent += 1
+		if seat1_adjacent > 0 and seat2_adjacent > 0:
+			obj.captured_by = 0
+		elif seat1_adjacent > 0:
+			obj.captured_by = 1
+		elif seat2_adjacent > 0:
+			obj.captured_by = 2
+		# else: retain obj.captured_by (captured objective stays captured
+		# until enemy contests or claims it).
+
+
+## Check for victory condition. Read-only; returns { winner, reason }.
+## winner = 1 or 2 for a decisive result, 0 for "no winner yet" OR draw
+## (the reason string disambiguates).
+static func check_victory(state: Types.GameState) -> Dictionary:
+	var units_total_1: int = 0
+	var units_total_2: int = 0
+	var units_alive_1: int = 0
+	var units_alive_2: int = 0
+
+	for unit in state.units:
+		if unit.owner_seat == 1:
+			units_total_1 += 1
+			if not unit.is_dead:
+				units_alive_1 += 1
+		else:
+			units_total_2 += 1
+			if not unit.is_dead:
+				units_alive_2 += 1
+
+	# Solo mode: one side has no units at all — no victory check
+	if units_total_1 == 0 or units_total_2 == 0:
+		return {"winner": 0, "reason": ""}
+
+	if units_alive_1 == 0 and units_alive_2 > 0:
+		return {"winner": 2, "reason": "Player 1 eliminated"}
+	if units_alive_2 == 0 and units_alive_1 > 0:
+		return {"winner": 1, "reason": "Player 2 eliminated"}
+	if units_alive_1 == 0 and units_alive_2 == 0:
+		return {"winner": 0, "reason": "Draw (both eliminated)"}
+
+	# Headless Chicken: all Snobs dead = instant loss
+	var snobs_alive_1 = 0
+	var snobs_alive_2 = 0
+	for unit in state.units:
+		if not unit.is_dead and unit.is_snob():
+			if unit.owner_seat == 1:
+				snobs_alive_1 += 1
+			else:
+				snobs_alive_2 += 1
+
+	if snobs_alive_1 == 0 and snobs_alive_2 > 0:
+		return {"winner": 2, "reason": "Player 1 lost all Snobs (Headless Chicken)"}
+	if snobs_alive_2 == 0 and snobs_alive_1 > 0:
+		return {"winner": 1, "reason": "Player 2 lost all Snobs (Headless Chicken)"}
+
+	# Round limit reached: v17 objective scoring (core p.22, scenarios p.23+).
+	# "The player who controls the most objective markers at the end of the
+	# final round is the victor." Ties go straight to draw — no secondary
+	# model-count fallback in the rules.
+	if state.current_round > state.max_rounds:
+		var objectives_1: int = 0
+		var objectives_2: int = 0
+		for obj in state.objectives:
+			if obj.captured_by == 1:
+				objectives_1 += 1
+			elif obj.captured_by == 2:
+				objectives_2 += 1
+		if objectives_1 > objectives_2:
+			return {"winner": 1, "reason": "Player 1 controls %d objective(s) to %d" % [objectives_1, objectives_2]}
+		if objectives_2 > objectives_1:
+			return {"winner": 2, "reason": "Player 2 controls %d objective(s) to %d" % [objectives_2, objectives_1]}
+		return {"winner": 0, "reason": "Objectives tied %d–%d (Draw)" % [objectives_1, objectives_2]}
+
+	return {"winner": 0, "reason": ""}

--- a/godot/game/panic.gd
+++ b/godot/game/panic.gd
@@ -1,0 +1,229 @@
+class_name Panic
+extends RefCounted
+## Panic tests, Fearless override, and forced retreat movement.
+##
+## Pure RefCounted, no node deps. Mutates the GameState in place when
+## executing retreat (moves the unit, marks it dead on board-edge).
+##
+## V17 model:
+##   - Panic test (v17 core p.19): roll D6 + panic_tokens. ≤6 pass, ≥7 fail.
+##     Natural 1 always passes. 0 tokens auto-pass (skip the test entirely).
+##   - Fearless override: a unit that fails its panic test gets a second
+##     chance if Fearless. fearless_die ≥ 3 = override to pass.
+##     Sources of Fearless: "fearless" rule (Brutes) or "safety_in_numbers"
+##     with model_count ≥ 8 (Fodder).
+##   - Retreat (v17 core p.20): D6 + 2" per panic token, away from nearest
+##     enemy. Off-board ends the unit (destroyed). Stubborn Fanatics never
+##     retreat (Stump Gun). DT through Followers deferred to terrain (#58).
+
+const Board = preload("res://game/board.gd")
+
+
+## Check whether a unit is currently Fearless (3+ to ignore forced retreat).
+## Sources: "fearless" special rule (Brutes), or "safety_in_numbers" with 8+
+## models alive (Fodder).
+static func is_fearless(unit: Types.UnitState) -> bool:
+	if "fearless" in unit.special_rules:
+		return true
+	if "safety_in_numbers" in unit.special_rules and unit.model_count >= 8:
+		return true
+	return false
+
+
+## Panic test per v17 core p.19.
+## Roll D6 + panic_tokens: ≤6 pass, ≥7 fail (must retreat).
+## Natural 1 always passes. 0 tokens auto-pass (skip test).
+## Fearless units that fail get a second chance: fearless_die 3+ = override to pass.
+##
+## Returns { passed, roll, total, auto_passed, fearless_override, used_fearless }.
+## Does NOT modify unit state — caller applies consequences.
+static func panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int) -> Dictionary:
+	var result = {
+		"passed": true,
+		"roll": panic_die,
+		"total": 0,
+		"auto_passed": false,
+		"fearless_override": false,
+		"used_fearless": false,
+	}
+
+	# 0 tokens = auto-pass (v17: "units with zero panic tokens can skip the test")
+	if unit.panic_tokens == 0:
+		result["auto_passed"] = true
+		return result
+
+	# Natural 1 always passes
+	if panic_die == 1:
+		return result
+
+	var total: int = panic_die + unit.panic_tokens
+	result["total"] = total
+
+	if total <= 6:
+		# Passed normally
+		return result
+
+	# Failed — check Fearless override
+	if is_fearless(unit):
+		result["used_fearless"] = true
+		if fearless_die >= 3:
+			result["fearless_override"] = true
+			return result
+
+	result["passed"] = false
+	return result
+
+
+## Find the nearest alive enemy unit to the given unit.
+static func find_nearest_enemy(state: Types.GameState, unit: Types.UnitState) -> Types.UnitState:
+	var best: Types.UnitState = null
+	var best_dist: float = 99999.0
+	for u in state.units:
+		if u.is_dead or u.owner_seat == unit.owner_seat:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		var d := Board.grid_distance(unit.x, unit.y, u.x, u.y)
+		if d < best_dist:
+			best_dist = d
+			best = u
+	return best
+
+
+## Execute retreat for a unit. Mutates state in place.
+## v17 core p.20: move directly away from closest enemy, D6 + 2" per panic
+## token. Board edge = unit destroyed. Stubborn Fanatics never retreat.
+##
+## `retreat_die` is a pre-rolled D6 supplied by the caller (1..6). Pass 1 for
+## the minimum distance when a test intentionally suppresses the D6 component.
+##
+## Returns { retreated, destroyed, from_x, from_y, to_x, to_y, distance,
+##           retreat_die, stubborn_held, no_enemy }.
+## DT tests for crossing Followers deferred to terrain system (#58).
+static func execute_retreat(state: Types.GameState, unit_id: String, retreat_die: int) -> Dictionary:
+	var unit = _find_unit(state, unit_id)
+	var result = {
+		"retreated": false,
+		"destroyed": false,
+		"from_x": unit.x, "from_y": unit.y,
+		"to_x": unit.x, "to_y": unit.y,
+		"distance": 0,
+		"retreat_die": retreat_die,
+		"stubborn_held": false,
+		"no_enemy": false,
+	}
+
+	if not unit or unit.is_dead:
+		return result
+
+	# Stubborn Fanatics: never retreat (Stump Gun)
+	if "stubborn_fanatics" in unit.special_rules:
+		result["stubborn_held"] = true
+		return result
+
+	# Retreat distance: D6 + 2" per panic token (v17 core p.20).
+	var retreat_dist: int = retreat_die + unit.panic_tokens * 2
+	result["distance"] = retreat_dist
+
+	# Direction: away from nearest alive enemy
+	var nearest_enemy = find_nearest_enemy(state, unit)
+	if not nearest_enemy:
+		# No enemies alive — nowhere to retreat from. Stay put.
+		result["no_enemy"] = true
+		return result
+
+	var dx: float = float(unit.x - nearest_enemy.x)
+	var dy: float = float(unit.y - nearest_enemy.y)
+	var dist: float = sqrt(dx * dx + dy * dy)
+	if dist < 0.001:
+		# On top of enemy (shouldn't happen). Default direction: toward own deployment zone.
+		dy = 1.0 if unit.owner_seat == 1 else -1.0
+		dx = 0.0
+		dist = 1.0
+
+	# Normalize direction
+	dx /= dist
+	dy /= dist
+
+	# Ideal retreat destination
+	var ideal_x: float = float(unit.x) + dx * float(retreat_dist)
+	var ideal_y: float = float(unit.y) + dy * float(retreat_dist)
+	var target_x: int = clampi(roundi(ideal_x), 0, Board.BOARD_WIDTH - 1)
+	var target_y: int = clampi(roundi(ideal_y), 0, Board.BOARD_HEIGHT - 1)
+
+	# Board edge check: if the ideal position is off the board, unit is destroyed.
+	if not Board.is_in_bounds(roundi(ideal_x), roundi(ideal_y)):
+		unit.is_dead = true
+		unit.model_count = 0
+		unit.x = -1
+		unit.y = -1
+		result["retreated"] = true
+		result["destroyed"] = true
+		result["to_x"] = -1
+		result["to_y"] = -1
+		return result
+
+	# Find the best valid cell near the target
+	var dest = _find_retreat_cell(state, unit, target_x, target_y)
+	if dest.x == -1:
+		# No valid cell found — stay in place (edge case, shouldn't normally happen)
+		return result
+
+	unit.x = dest.x
+	unit.y = dest.y
+	result["retreated"] = true
+	result["to_x"] = dest.x
+	result["to_y"] = dest.y
+	return result
+
+
+## Find a valid retreat destination cell near (target_x, target_y).
+## Searches the target cell first, then spirals outward. Returns Vector2i(-1,-1)
+## if nothing found within a reasonable radius.
+static func _find_retreat_cell(state: Types.GameState, unit: Types.UnitState, target_x: int, target_y: int) -> Vector2i:
+	# Try the ideal cell first
+	if _is_valid_retreat_dest(state, unit, target_x, target_y):
+		return Vector2i(target_x, target_y)
+
+	# Spiral outward looking for an alternative
+	for radius in range(1, 6):
+		var best = Vector2i(-1, -1)
+		var best_dist: float = 99999.0
+		for dy in range(-radius, radius + 1):
+			for dx in range(-radius, radius + 1):
+				if abs(dx) != radius and abs(dy) != radius:
+					continue  # Skip inner cells already checked
+				var cx: int = target_x + dx
+				var cy: int = target_y + dy
+				if _is_valid_retreat_dest(state, unit, cx, cy):
+					var d := Board.grid_distance(target_x, target_y, cx, cy)
+					if d < best_dist:
+						best_dist = d
+						best = Vector2i(cx, cy)
+		if best.x != -1:
+			return best
+
+	return Vector2i(-1, -1)
+
+
+## Is this cell a valid retreat destination? Bounds, not occupied by another
+## live unit, not on an objective marker (v17 p.22).
+static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> bool:
+	if not Board.is_in_bounds(x, y):
+		return false
+	for u in state.units:
+		if not u.is_dead and u.id != unit.id and u.x == x and u.y == y:
+			return false
+	for obj in state.objectives:
+		if obj.x == x and obj.y == y:
+			return false
+	return true
+
+
+## Find a unit by ID in a GameState. Local helper so panic.gd doesn't need
+## to depend on the engine's _find_unit.
+static func _find_unit(state: Types.GameState, unit_id: String) -> Types.UnitState:
+	for u in state.units:
+		if u.id == unit_id:
+			return u
+	return null

--- a/godot/game/targeting.gd
+++ b/godot/game/targeting.gd
@@ -1,0 +1,181 @@
+class_name Targeting
+extends RefCounted
+## Line of sight, valid-target enumeration, and charge-cell selection.
+##
+## Pure RefCounted, no node deps. Imported by both the server engine
+## (authoritative validation) and the client renderer (target rings,
+## "is this enemy reachable" hints) so client and server cannot diverge
+## on what counts as a legal target.
+##
+## V17 model:
+##   - Supercover line of sight (modified Bresenham) — every cell the
+##     line touches is checked. Snobs and dead units never block (v17 p.5).
+##   - Closest-target restriction on shooting (v17 p.12). Sharpshooters
+##     bypass the closest rule but still need range + LoS.
+##   - Diagonals are full Euclidean distance (sqrt(dx² + dy²)), so a
+##     diagonal-adjacent cell is at √2 ≈ 1.41, NOT 1.
+
+const Board = preload("res://game/board.gd")
+
+
+## Supercover line-of-sight check between two grid cells.
+## Returns true if no alive non-Snob unit (except the two endpoints) occupies
+## any cell the line passes through. Snobs never block LoS (v17 p.5).
+static func has_line_of_sight(state: Types.GameState, from_x: int, from_y: int, to_x: int, to_y: int) -> bool:
+	# Build a set of occupied cells that block LoS (alive non-Snob Followers).
+	# Exclude the two endpoint cells.
+	var blockers: Dictionary = {}  # "x,y" -> true
+	for u in state.units:
+		if u.is_dead or u.is_snob():
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		if (u.x == from_x and u.y == from_y) or (u.x == to_x and u.y == to_y):
+			continue
+		blockers["%d,%d" % [u.x, u.y]] = true
+
+	if blockers.is_empty():
+		return true
+
+	# Supercover line walk: enumerate every cell the line from center of
+	# (from_x, from_y) to center of (to_x, to_y) touches or crosses.
+	var dx: int = to_x - from_x
+	var dy: int = to_y - from_y
+	var sx: int = 1 if dx > 0 else (-1 if dx < 0 else 0)
+	var sy: int = 1 if dy > 0 else (-1 if dy < 0 else 0)
+	var adx: int = abs(dx)
+	var ady: int = abs(dy)
+
+	var cx: int = from_x
+	var cy: int = from_y
+
+	# Modified Bresenham for supercover (checks diagonal-adjacent cells).
+	var error: int = adx - ady
+
+	var steps: int = adx + ady
+	for _i in range(steps):
+		var e2: int = 2 * error
+		if e2 > -ady and e2 < adx:
+			# Diagonal step — supercover: check both axis-adjacent cells too
+			if blockers.has("%d,%d" % [cx + sx, cy]):
+				return false
+			if blockers.has("%d,%d" % [cx, cy + sy]):
+				return false
+			cx += sx
+			cy += sy
+			error += -ady + adx
+		elif e2 > -ady:
+			cx += sx
+			error -= ady
+		else:
+			cy += sy
+			error += adx
+
+		# Skip endpoint
+		if cx == to_x and cy == to_y:
+			break
+		if blockers.has("%d,%d" % [cx, cy]):
+			return false
+
+	return true
+
+
+## Find all valid shooting targets for a unit: alive enemies in weapon range
+## with line of sight.
+static func find_shooting_targets(state: Types.GameState, shooter: Types.UnitState) -> Array:
+	return find_shooting_targets_from(state, shooter, shooter.x, shooter.y)
+
+
+## Find shooting targets from an arbitrary position (for move_and_shoot post-move).
+static func find_shooting_targets_from(state: Types.GameState, shooter: Types.UnitState, from_x: int, from_y: int) -> Array:
+	var targets: Array = []
+	var wr: int = shooter.base_stats.weapon_range
+	if wr <= 0:
+		return targets
+	for u in state.units:
+		if u.is_dead or u.owner_seat == shooter.owner_seat:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		var d := Board.grid_distance(from_x, from_y, u.x, u.y)
+		if d <= wr and has_line_of_sight(state, from_x, from_y, u.x, u.y):
+			targets.append(u)
+	return targets
+
+
+## Validate whether a specific target is legal for shooting.
+## Returns "" if valid, error string if not. Enforces closest-target rule
+## (v17 p.12): must target the closest valid enemy in range + LoS (ties
+## allowed — any tied target is legal). Sharpshooters bypass closest but
+## still need LoS.
+static func is_valid_shooting_target(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState) -> String:
+	return is_valid_shooting_target_from(state, shooter, target, shooter.x, shooter.y)
+
+
+## Same as is_valid_shooting_target but with the shooter at (from_x, from_y)
+## (used for move_and_shoot post-move validation).
+static func is_valid_shooting_target_from(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState, from_x: int, from_y: int) -> String:
+	if target.is_dead:
+		return "Target is dead"
+	if target.owner_seat == shooter.owner_seat:
+		return "Cannot target your own units"
+
+	var distance := Board.grid_distance(from_x, from_y, target.x, target.y)
+	if distance > shooter.base_stats.weapon_range:
+		return "Target out of range (max %d)" % shooter.base_stats.weapon_range
+
+	if not has_line_of_sight(state, from_x, from_y, target.x, target.y):
+		return "No line of sight to target"
+
+	# Closest-target enforcement (skip for Sharpshooters)
+	if "sharpshooters" not in shooter.special_rules:
+		var valid_targets := find_shooting_targets_from(state, shooter, from_x, from_y)
+		if valid_targets.is_empty():
+			return "No valid targets in range with LoS"
+		var min_dist: float = 99999.0
+		for vt in valid_targets:
+			var vd := Board.grid_distance(from_x, from_y, vt.x, vt.y)
+			if vd < min_dist:
+				min_dist = vd
+		if distance > min_dist + 0.01:  # epsilon for float comparison
+			return "Must target closest enemy (closest is at %.1f, target is at %.1f)" % [min_dist, distance]
+
+	return ""
+
+
+## Find the best adjacent cell to a target for a charging unit.
+##
+## Currently checks only 4-cardinal neighbors (N/S/E/W). Diagonal-adjacent
+## charge contact (within √2) is rejected — tracked separately as a bug
+## (#77) and lives here so the fix only touches one file.
+static func find_adjacent_cell(state: Types.GameState, charger: Types.UnitState, target: Types.UnitState) -> Vector2i:
+	var best = Vector2i(-1, -1)
+	var best_dist = 9999
+
+	for offset in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
+		var cx = target.x + offset.x
+		var cy = target.y + offset.y
+		if not Board.is_in_bounds(cx, cy):
+			continue
+		# Not occupied by another live unit (charger may "occupy" its source).
+		var occupied = false
+		for u in state.units:
+			if not u.is_dead and u.x == cx and u.y == cy and u.id != charger.id:
+				occupied = true
+				break
+		if occupied:
+			continue
+		# Objective cells are invalid end-of-move destinations (v17 p.22).
+		var on_objective = false
+		for obj in state.objectives:
+			if obj.x == cx and obj.y == cy:
+				on_objective = true
+				break
+		if on_objective:
+			continue
+		var dist = Board.grid_distance(charger.x, charger.y, cx, cy)
+		if dist < best_dist:
+			best_dist = dist
+			best = Vector2i(cx, cy)
+
+	return best

--- a/godot/game/types.gd
+++ b/godot/game/types.gd
@@ -96,7 +96,7 @@ class UnitDef extends RefCounted:
 		category = p_category
 		model_count = p_model_count
 		base_stats = p_base_stats if p_base_stats else Stats.new()
-		special_rules = p_special_rules
+		special_rules = p_special_rules.duplicate()
 		allowed_equipment = p_allowed_equipment
 		description = p_description
 
@@ -274,7 +274,7 @@ class UnitState extends RefCounted:
 		max_models = p_max_models
 		base_stats = p_base_stats if p_base_stats else Stats.new()
 		equipment = p_equipment
-		special_rules = p_special_rules
+		special_rules = p_special_rules.duplicate()
 		panic_tokens = p_panic_tokens
 		has_powder_smoke = p_has_powder_smoke
 		current_wounds = p_current_wounds

--- a/godot/game/types.gd
+++ b/godot/game/types.gd
@@ -483,28 +483,30 @@ class GameState extends RefCounted:
 
 ## Result of an engine operation.
 class EngineResult extends RefCounted:
-	var success: bool = false
+	## Outcome of a single engine call. `error.is_empty()` IS success — there
+	## is no separate boolean. The previous redundant `success` field made it
+	## possible to set one without the other and was a contract trap.
 	var error: String = ""
 	var new_state: GameState = null
 	var dice_rolled: Array = []
 	var description: String = ""
 
 	func _init(
-		p_success: bool = false,
 		p_error: String = "",
 		p_new_state: GameState = null,
 		p_dice_rolled: Array = [],
 		p_description: String = ""
 	) -> void:
-		success = p_success
 		error = p_error
 		new_state = p_new_state
 		dice_rolled = p_dice_rolled
 		description = p_description
 
+	func is_success() -> bool:
+		return error.is_empty()
+
 	func to_dict() -> Dictionary:
 		return {
-			"success": success,
 			"error": error,
 			"new_state": new_state.to_dict() if new_state else {},
 			"dice_rolled": dice_rolled,

--- a/godot/game/types.gd
+++ b/godot/game/types.gd
@@ -452,7 +452,8 @@ class GameState extends RefCounted:
 
 		var action_log_array: Array[Dictionary] = []
 		if data.has("action_log"):
-			action_log_array.assign(data["action_log"])
+			for entry in data["action_log"]:
+				action_log_array.append((entry as Dictionary).duplicate(true))
 
 		var gs = GameState.new(
 			data.get("room_code", ""),

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -112,7 +112,6 @@ static func place_unit(state: Types.GameState, unit_id: String, x: int, y: int) 
 		"y": y
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.description = "%s placed at (%d, %d)" % [unit.unit_type, x, y]
 
@@ -165,7 +164,6 @@ static func confirm_placement(state: Types.GameState) -> Types.EngineResult:
 		})
 		result.description = "Player %d placement confirmed. Player %d's turn." % [state.active_seat, other_seat]
 
-	result.success = true
 	result.new_state = new_state
 
 	return result
@@ -215,7 +213,6 @@ static func select_snob(state: Types.GameState, snob_id: String) -> Types.Engine
 		"snob_type": snob.unit_type
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.description = "%s Made Ready" % snob.unit_type
 
@@ -331,7 +328,6 @@ static func declare_order(state: Types.GameState, unit_id: String, order_type: S
 		"move_bonus": move_bonus
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = [blunder_die] + move_dice
 	result.description = "%s ordered to %s%s (move bonus: +%d)" % [
@@ -421,7 +417,6 @@ static func declare_self_order(state: Types.GameState, unit_id: String, order_ty
 		"move_bonus": move_bonus
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = [blunder_die] + move_dice
 	var blunder_text = " [BLUNDERED!]" if blundered else ""
@@ -490,7 +485,6 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 			"unit_type": unit.unit_type,
 			"blundered": state.current_order_blundered
 		})
-		result.success = true
 		result.new_state = fizzled_state
 		result.description = "%s volley fire fizzled (no targets in range)" % unit.unit_type
 		return result
@@ -551,7 +545,6 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 		"retreat": retreat,
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = dice_results
 	var blunder_text = " (blundered, no bonus)" if state.current_order_blundered else " (-1 Inaccuracy)"
@@ -665,7 +658,6 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 		"retreat": retreat,
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = dice_results
 	var shoot_text = ""
@@ -718,7 +710,6 @@ static func _execute_march(state: Types.GameState, unit: Types.UnitState, params
 		"blundered": state.current_order_blundered
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.description = "March! %s to (%d,%d) (M%d + %d)" % [
 		unit.unit_type, x, y, unit.base_stats.movement, state.current_order_move_bonus
@@ -745,7 +736,6 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 			"unit_type": unit.unit_type,
 			"blundered": state.current_order_blundered
 		})
-		result.success = true
 		result.new_state = fizzled_state
 		result.description = "%s charge fizzled (no targets in range)" % unit.unit_type
 		return result
@@ -826,7 +816,6 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 			"hits": 0, "saves": 0, "unsaved_wounds": 0
 		})
 
-		result.success = true
 		result.new_state = new_state
 		result.dice_rolled = [panic_die, fearless_die]
 		var retreat_text = ""
@@ -903,7 +892,6 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		"counter_unsaved_wounds": def_wounds_total,
 	})
 
-	result.success = true
 	result.new_state = new_state
 	result.dice_rolled = [panic_die, fearless_die] + dice_results
 	var panic_text = ""

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -23,10 +23,6 @@ const Combat = preload("res://game/combat.gd")
 const Panic = preload("res://game/panic.gd")
 const Objectives = preload("res://game/objectives.gd")
 
-# Re-exported so existing GameEngine.MELEE_MAX_BOUTS callers compile.
-# Authoritative definition lives in game/combat.gd.
-const MELEE_MAX_BOUTS: int = Combat.MELEE_MAX_BOUTS
-
 
 # =============================================================================
 # PLACEMENT PHASE
@@ -494,7 +490,7 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 	var new_unit = _find_unit(new_state, unit.id)
 	var new_target = _find_unit(new_state, target_id)
 
-	var combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, inaccuracy_mod)
+	var combat = Combat.resolve_shooting_engagement(new_unit, new_target, dice_results, inaccuracy_mod)
 	if combat["error"] != "":
 		result.error = combat["error"]
 		return result
@@ -609,7 +605,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 			# Validate from post-move position: range + LoS + closest-target
 			var shoot_error = Targeting.is_valid_shooting_target_from(new_state, new_unit, new_target, x, y)
 			if shoot_error == "" and not new_unit.has_powder_smoke:
-				combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, 0)
+				combat = Combat.resolve_shooting_engagement(new_unit, new_target, dice_results, 0)
 				if combat["error"] != "":
 					result.error = combat["error"]
 					return result
@@ -821,7 +817,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	new_unit.y = charge_dest.y
 
 	# Resolve melee as bouts (v17 core p.18)
-	var combat = _resolve_melee(new_unit, new_target, dice_results)
+	var combat = Combat.resolve_melee(new_unit, new_target, dice_results)
 	if combat["error"] != "":
 		result.error = combat["error"]
 		return result
@@ -1019,52 +1015,6 @@ static func _find_nearest_enemy(state: Types.GameState, unit: Types.UnitState) -
 
 
 # =============================================================================
-# COMBAT RESOLUTION HELPERS
-# =============================================================================
-
-## Thin wrappers — implementations live in game/combat.gd.
-static func _resolve_shooting_side(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, offset: int, inaccuracy_mod: int) -> Dictionary:
-	return Combat.resolve_shooting_side(attacker, target, dice_results, offset, inaccuracy_mod)
-
-
-static func _can_return_fire(target: Types.UnitState, shooter: Types.UnitState) -> bool:
-	return Combat.can_return_fire(target, shooter)
-
-
-## Resolve a shooting engagement (v17 core p.13). Both sides roll against
-## pre-engagement model counts — casualties from the primary strike do not
-## suppress return fire. Wounds, smoke, and hit-panic tokens applied after
-## both sides have rolled.
-##
-## Winner = side that dealt more unsaved wounds. Tie = no winner, no retreat
-## (caller still runs _execute_retreat only when winner/loser set).
-##
-## Returns {
-##   att_hits, att_saves, att_wounds,
-##   def_hits, def_saves, def_wounds,
-##   return_fire_fired: bool,
-##   winner_id, loser_id,           # "" on tie
-##   tie: bool,
-##   dice_used: int,
-##   error: String
-## }
-static func _resolve_shooting_engagement(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, attacker_inaccuracy_mod: int) -> Dictionary:
-	return Combat.resolve_shooting_engagement(attacker, target, dice_results, attacker_inaccuracy_mod)
-
-
-static func _resolve_bout_side(attacker: Types.UnitState, defender: Types.UnitState, dice_results: Array, offset: int) -> Dictionary:
-	return Combat.resolve_bout_side(attacker, defender, dice_results, offset)
-
-
-static func _melee_dice_budget(attacker: Types.UnitState, defender: Types.UnitState) -> int:
-	return Combat.melee_dice_budget(attacker, defender)
-
-
-static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array) -> Dictionary:
-	return Combat.resolve_melee(attacker, target, dice_results)
-
-
-# =============================================================================
 # VICTORY CONDITION
 # =============================================================================
 
@@ -1077,11 +1027,6 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 # =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
-
-## Thin wrapper — implementation in game/combat.gd.
-static func _apply_wounds(unit: Types.UnitState, wounds: int) -> void:
-	Combat.apply_wounds(unit, wounds)
-
 
 ## Deep clone a GameState.
 static func _clone_state(state: Types.GameState) -> Types.GameState:

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -130,7 +130,7 @@ static func confirm_placement(state: Types.GameState) -> Types.EngineResult:
 		new_state.active_seat = new_state.initiative_seat
 		# v17 p.22: "Objectives with units deployed within 1" are considered
 		# captured." Run the resolver once deployment is final.
-		_resolve_objective_captures(new_state)
+		Objectives.resolve_objective_captures(new_state)
 		new_state.action_log.append({
 			"round": state.current_round,
 			"action": "orders_phase_started"
@@ -915,7 +915,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 ## Marks units as ordered, switches players, transitions phases.
 static func _advance_after_order(state: Types.GameState) -> void:
 	# Re-resolve objective control after any positional or unit-death change.
-	_resolve_objective_captures(state)
+	Objectives.resolve_objective_captures(state)
 
 	# Mark the ordered unit
 	var unit = _find_unit(state, state.current_order_unit_id)
@@ -989,16 +989,6 @@ static func _end_round(state: Types.GameState) -> void:
 
 
 # =============================================================================
-# VICTORY CONDITION
-# =============================================================================
-
-## Thin wrapper — implementation in game/objectives.gd. Public (no underscore)
-## because external callers (network_server, victory banner) use the legacy name.
-static func check_victory(state: Types.GameState) -> Dictionary:
-	return Objectives.check_victory(state)
-
-
-# =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
 
@@ -1067,14 +1057,5 @@ static func get_followers_in_command_range(state: Types.GameState, snob_id: Stri
 				result.append(unit.id)
 
 	return result
-
-
-## Thin wrappers — implementations live in game/objectives.gd.
-static func _is_objective_at(state: Types.GameState, x: int, y: int) -> bool:
-	return Objectives.is_objective_at(state, x, y)
-
-
-static func _resolve_objective_captures(state: Types.GameState) -> void:
-	Objectives.resolve_objective_captures(state)
 
 

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -15,9 +15,11 @@ extends RefCounted
 ##   6. Round ends, advance to next round
 
 # Board geometry, distance, and move validation live in game/board.gd.
-# Preloaded (not class_name) so headless test runs don't depend on the
-# global script class cache being up to date.
+# Targeting (LoS, valid-target enumeration, charge contact) lives in
+# game/targeting.gd. Preloaded (not class_name) so headless test runs
+# don't depend on the global script class cache being up to date.
 const Board = preload("res://game/board.gd")
+const Targeting = preload("res://game/targeting.gd")
 
 # Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
 # the server still compile during the staged module split.
@@ -1581,171 +1583,26 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 # LINE OF SIGHT + TARGETING
 # =============================================================================
 
-## Supercover line-of-sight check between two grid cells.
-## Returns true if no alive non-Snob unit (except the two endpoints) occupies
-## any cell the line passes through. Snobs never block LoS (v17 p.5).
-## Both endpoints are excluded from the blocker check.
+## Thin wrappers — implementations live in game/targeting.gd. Removed in a
+## follow-up once internal callers move to Targeting.* directly.
 static func _has_line_of_sight(state: Types.GameState, from_x: int, from_y: int, to_x: int, to_y: int) -> bool:
-	# Build a set of occupied cells that block LoS (alive non-Snob Followers).
-	# Exclude the two endpoint cells.
-	var blockers: Dictionary = {}  # "x,y" -> true
-	for u in state.units:
-		if u.is_dead or u.is_snob():
-			continue
-		if u.x < 0 or u.y < 0:
-			continue
-		if (u.x == from_x and u.y == from_y) or (u.x == to_x and u.y == to_y):
-			continue
-		blockers["%d,%d" % [u.x, u.y]] = true
-
-	if blockers.is_empty():
-		return true
-
-	# Supercover line walk: enumerate every cell the line from center of
-	# (from_x, from_y) to center of (to_x, to_y) touches or crosses.
-	var dx: int = to_x - from_x
-	var dy: int = to_y - from_y
-	var sx: int = 1 if dx > 0 else (-1 if dx < 0 else 0)
-	var sy: int = 1 if dy > 0 else (-1 if dy < 0 else 0)
-	var adx: int = abs(dx)
-	var ady: int = abs(dy)
-
-	var cx: int = from_x
-	var cy: int = from_y
-
-	# Use a modified Bresenham for supercover (checks diagonal-adjacent cells).
-	# error tracks which axis to step. When error triggers both, step diag and
-	# also check the two axis-only neighbors for coverage.
-	var error: int = adx - ady
-
-	var steps: int = adx + ady
-	for _i in range(steps):
-		var e2: int = 2 * error
-		if e2 > -ady and e2 < adx:
-			# Diagonal step — supercover: check both axis-adjacent cells too
-			if blockers.has("%d,%d" % [cx + sx, cy]):
-				return false
-			if blockers.has("%d,%d" % [cx, cy + sy]):
-				return false
-			cx += sx
-			cy += sy
-			error += -ady + adx
-		elif e2 > -ady:
-			cx += sx
-			error -= ady
-		else:
-			cy += sy
-			error += adx
-
-		# Skip endpoint
-		if cx == to_x and cy == to_y:
-			break
-		if blockers.has("%d,%d" % [cx, cy]):
-			return false
-
-	return true
+	return Targeting.has_line_of_sight(state, from_x, from_y, to_x, to_y)
 
 
-## Find all valid shooting targets for a unit: alive enemies in weapon range
-## with line of sight.
 static func _find_shooting_targets(state: Types.GameState, shooter: Types.UnitState) -> Array:
-	var targets: Array = []
-	var wr: int = shooter.base_stats.weapon_range
-	if wr <= 0:
-		return targets
-	for u in state.units:
-		if u.is_dead or u.owner_seat == shooter.owner_seat:
-			continue
-		if u.x < 0 or u.y < 0:
-			continue
-		var d := _grid_distance(shooter.x, shooter.y, u.x, u.y)
-		if d <= wr and _has_line_of_sight(state, shooter.x, shooter.y, u.x, u.y):
-			targets.append(u)
-	return targets
+	return Targeting.find_shooting_targets(state, shooter)
 
 
-## Find shooting targets from an arbitrary position (for move_and_shoot post-move).
 static func _find_shooting_targets_from(state: Types.GameState, shooter: Types.UnitState, from_x: int, from_y: int) -> Array:
-	var targets: Array = []
-	var wr: int = shooter.base_stats.weapon_range
-	if wr <= 0:
-		return targets
-	for u in state.units:
-		if u.is_dead or u.owner_seat == shooter.owner_seat:
-			continue
-		if u.x < 0 or u.y < 0:
-			continue
-		var d := _grid_distance(from_x, from_y, u.x, u.y)
-		if d <= wr and _has_line_of_sight(state, from_x, from_y, u.x, u.y):
-			targets.append(u)
-	return targets
+	return Targeting.find_shooting_targets_from(state, shooter, from_x, from_y)
 
 
-## Validate whether a specific target is legal for shooting.
-## Returns empty string if valid, error string if not.
-## Enforces closest-target rule (v17 p.12): must target the closest valid
-## enemy in range + LoS (ties are permissive — any tied target is legal).
-## Sharpshooters bypass the closest-target restriction but still need LoS.
 static func _is_valid_shooting_target(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState) -> String:
-	if target.is_dead:
-		return "Target is dead"
-	if target.owner_seat == shooter.owner_seat:
-		return "Cannot target your own units"
-
-	var distance := _grid_distance(shooter.x, shooter.y, target.x, target.y)
-	if distance > shooter.base_stats.weapon_range:
-		return "Target out of range (max %d)" % shooter.base_stats.weapon_range
-
-	if not _has_line_of_sight(state, shooter.x, shooter.y, target.x, target.y):
-		return "No line of sight to target"
-
-	# Closest-target enforcement (skip for Sharpshooters)
-	if "sharpshooters" not in shooter.special_rules:
-		var valid_targets := _find_shooting_targets(state, shooter)
-		if valid_targets.is_empty():
-			return "No valid targets in range with LoS"
-		# Find the minimum distance among valid targets
-		var min_dist: float = 99999.0
-		for vt in valid_targets:
-			var vd := _grid_distance(shooter.x, shooter.y, vt.x, vt.y)
-			if vd < min_dist:
-				min_dist = vd
-		# Target must be among the closest (ties allowed)
-		if distance > min_dist + 0.01:  # small epsilon for float comparison
-			return "Must target closest enemy (closest is at %.1f, target is at %.1f)" % [min_dist, distance]
-
-	return ""
+	return Targeting.is_valid_shooting_target(state, shooter, target)
 
 
-## Same as _is_valid_shooting_target but checks LoS from an arbitrary position
-## (for move_and_shoot post-move validation).
 static func _is_valid_shooting_target_from(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState, from_x: int, from_y: int) -> String:
-	if target.is_dead:
-		return "Target is dead"
-	if target.owner_seat == shooter.owner_seat:
-		return "Cannot target your own units"
-
-	var distance := _grid_distance(from_x, from_y, target.x, target.y)
-	if distance > shooter.base_stats.weapon_range:
-		return "Target out of range (max %d)" % shooter.base_stats.weapon_range
-
-	if not _has_line_of_sight(state, from_x, from_y, target.x, target.y):
-		return "No line of sight to target"
-
-	# Closest-target enforcement (skip for Sharpshooters)
-	if "sharpshooters" not in shooter.special_rules:
-		var valid_targets := _find_shooting_targets_from(state, shooter, from_x, from_y)
-		if valid_targets.is_empty():
-			return "No valid targets in range with LoS"
-		var min_dist: float = 99999.0
-		for vt in valid_targets:
-			var vd := _grid_distance(from_x, from_y, vt.x, vt.y)
-			if vd < min_dist:
-				min_dist = vd
-		if distance > min_dist + 0.01:
-			return "Must target closest enemy (closest is at %.1f, target is at %.1f)" % [min_dist, distance]
-
-	return ""
+	return Targeting.is_valid_shooting_target_from(state, shooter, target, from_x, from_y)
 
 
 # =============================================================================
@@ -1890,30 +1747,6 @@ static func _resolve_objective_captures(state: Types.GameState) -> void:
 		# until enemy contests or claims it).
 
 
-## Find the best adjacent cell to a target for a charging unit.
+## Thin wrapper — implementation in game/targeting.gd.
 static func _find_adjacent_cell(state: Types.GameState, charger: Types.UnitState, target: Types.UnitState) -> Vector2i:
-	var best = Vector2i(-1, -1)
-	var best_dist = 9999
-
-	for offset in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
-		var cx = target.x + offset.x
-		var cy = target.y + offset.y
-		if cx < 0 or cx >= BOARD_WIDTH or cy < 0 or cy >= BOARD_HEIGHT:
-			continue
-		# Check not occupied (except by charger itself)
-		var occupied = false
-		for u in state.units:
-			if not u.is_dead and u.x == cx and u.y == cy and u.id != charger.id:
-				occupied = true
-				break
-		if occupied:
-			continue
-		# Objective cells are invalid end-of-move destinations (v17 p.22).
-		if _is_objective_at(state, cx, cy):
-			continue
-		var dist = _grid_distance(charger.x, charger.y, cx, cy)
-		if dist < best_dist:
-			best_dist = dist
-			best = Vector2i(cx, cy)
-
-	return best
+	return Targeting.find_adjacent_cell(state, charger, target)

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -14,29 +14,30 @@ extends RefCounted
 ##   5. After all Snobs ordered, unordered Followers order themselves
 ##   6. Round ends, advance to next round
 
-# Board constants
-const BOARD_WIDTH: int = 48
-const BOARD_HEIGHT: int = 32
+# Board geometry, distance, and move validation live in game/board.gd.
+# Preloaded (not class_name) so headless test runs don't depend on the
+# global script class cache being up to date.
+const Board = preload("res://game/board.gd")
 
-
-## Euclidean distance between two grid cells.
-## All range/movement checks use this instead of Manhattan distance so that
-## diagonal distances are geometrically correct (1 cell = 1 inch).
-static func _grid_distance(x1: int, y1: int, x2: int, y2: int) -> float:
-	var dx: int = x2 - x1
-	var dy: int = y2 - y1
-	return sqrt(float(dx * dx + dy * dy))
-
-# Deployment zones (4 rows each)
-const DEPLOYMENT_ZONE_1_Y_MIN: int = 28  # Bottom (seat 1)
-const DEPLOYMENT_ZONE_1_Y_MAX: int = 31
-const DEPLOYMENT_ZONE_2_Y_MIN: int = 0   # Top (seat 2)
-const DEPLOYMENT_ZONE_2_Y_MAX: int = 3
+# Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
+# the server still compile during the staged module split.
+const BOARD_WIDTH: int = Board.BOARD_WIDTH
+const BOARD_HEIGHT: int = Board.BOARD_HEIGHT
+const DEPLOYMENT_ZONE_1_Y_MIN: int = Board.DEPLOYMENT_ZONE_1_Y_MIN
+const DEPLOYMENT_ZONE_1_Y_MAX: int = Board.DEPLOYMENT_ZONE_1_Y_MAX
+const DEPLOYMENT_ZONE_2_Y_MIN: int = Board.DEPLOYMENT_ZONE_2_Y_MIN
+const DEPLOYMENT_ZONE_2_Y_MAX: int = Board.DEPLOYMENT_ZONE_2_Y_MAX
 
 # Melee bout cap — v17 has no hard limit, but tied bouts could loop forever on
 # whiffing dice. Cap at 3; unresolved ties after the cap end in a draw with no
 # retreat (both sides still take +1 panic per melee-ended rule).
 const MELEE_MAX_BOUTS: int = 3
+
+
+## Thin wrapper for the few in-engine callers that still use the legacy name.
+## Removed in a follow-up once all callers move to Board.grid_distance directly.
+static func _grid_distance(x1: int, y1: int, x2: int, y2: int) -> float:
+	return Board.grid_distance(x1, y1, x2, y2)
 
 
 # =============================================================================
@@ -1832,18 +1833,11 @@ static func get_followers_in_command_range(state: Types.GameState, snob_id: Stri
 	return result
 
 
-## Validate basic movement constraints (bounds, not occupied).
+## Thin wrapper retained so internal call sites still compile after the
+## board.gd extraction. Removed in a follow-up once callers move to
+## Board.validate_move directly.
 static func _validate_move(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> String:
-	if x < 0 or x >= BOARD_WIDTH or y < 0 or y >= BOARD_HEIGHT:
-		return "Coordinates out of bounds"
-	for u in state.units:
-		if not u.is_dead and u.x == x and u.y == y and u.id != unit.id:
-			return "Position occupied"
-	# v17 core p.22: "A unit may move across objectives, but may never finish
-	# a move on top of one."
-	if _is_objective_at(state, x, y):
-		return "Cannot end move on an objective marker"
-	return ""
+	return Board.validate_move(state, unit, x, y)
 
 
 ## Is there an objective marker at this cell?

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -481,7 +481,7 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 		return result
 
 	# LoS + range + closest-target validation
-	var target_error = _is_valid_shooting_target(state, unit, target)
+	var target_error = Targeting.is_valid_shooting_target(state, unit, target)
 	if target_error != "":
 		result.error = target_error
 		return result
@@ -607,7 +607,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 		new_target = _find_unit(new_state, target_id)
 		if new_target and not new_target.is_dead and new_target.owner_seat != unit.owner_seat:
 			# Validate from post-move position: range + LoS + closest-target
-			var shoot_error = _is_valid_shooting_target_from(new_state, new_unit, new_target, x, y)
+			var shoot_error = Targeting.is_valid_shooting_target_from(new_state, new_unit, new_target, x, y)
 			if shoot_error == "" and not new_unit.has_powder_smoke:
 				combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, 0)
 				if combat["error"] != "":
@@ -738,7 +738,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 
 	# LoS check (v17 p.16: must have LoS to charge target)
-	if not _has_line_of_sight(state, unit.x, unit.y, target.x, target.y):
+	if not Targeting.has_line_of_sight(state, unit.x, unit.y, target.x, target.y):
 		result.error = "No line of sight to charge target"
 		return result
 
@@ -750,7 +750,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 
 	# Find an adjacent cell to the target to move to
-	var charge_dest = _find_adjacent_cell(state, unit, target)
+	var charge_dest = Targeting.find_adjacent_cell(state, unit, target)
 	if charge_dest.x == -1:
 		result.error = "No open cell adjacent to target"
 		return result
@@ -1075,32 +1075,6 @@ static func check_victory(state: Types.GameState) -> Dictionary:
 
 
 # =============================================================================
-# LINE OF SIGHT + TARGETING
-# =============================================================================
-
-## Thin wrappers — implementations live in game/targeting.gd. Removed in a
-## follow-up once internal callers move to Targeting.* directly.
-static func _has_line_of_sight(state: Types.GameState, from_x: int, from_y: int, to_x: int, to_y: int) -> bool:
-	return Targeting.has_line_of_sight(state, from_x, from_y, to_x, to_y)
-
-
-static func _find_shooting_targets(state: Types.GameState, shooter: Types.UnitState) -> Array:
-	return Targeting.find_shooting_targets(state, shooter)
-
-
-static func _find_shooting_targets_from(state: Types.GameState, shooter: Types.UnitState, from_x: int, from_y: int) -> Array:
-	return Targeting.find_shooting_targets_from(state, shooter, from_x, from_y)
-
-
-static func _is_valid_shooting_target(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState) -> String:
-	return Targeting.is_valid_shooting_target(state, shooter, target)
-
-
-static func _is_valid_shooting_target_from(state: Types.GameState, shooter: Types.UnitState, target: Types.UnitState, from_x: int, from_y: int) -> String:
-	return Targeting.is_valid_shooting_target_from(state, shooter, target, from_x, from_y)
-
-
-# =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
 
@@ -1133,7 +1107,7 @@ static func _has_unordered_snobs(state: Types.GameState, seat: int) -> bool:
 
 ## Does at least one alive enemy unit sit inside the shooter's weapon range?
 static func _has_valid_volley_target(state: Types.GameState, unit: Types.UnitState) -> bool:
-	return not _find_shooting_targets(state, unit).is_empty()
+	return not Targeting.find_shooting_targets(state, unit).is_empty()
 
 
 ## Does at least one alive enemy unit sit inside the charger's M + move_bonus range with LoS?
@@ -1145,7 +1119,7 @@ static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitSta
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
 		var d := Board.grid_distance(unit.x, unit.y, u.x, u.y)
-		if d <= reach and _has_line_of_sight(state, unit.x, unit.y, u.x, u.y):
+		if d <= reach and Targeting.has_line_of_sight(state, unit.x, unit.y, u.x, u.y):
 			return true
 	return false
 
@@ -1185,6 +1159,3 @@ static func _resolve_objective_captures(state: Types.GameState) -> void:
 	Objectives.resolve_objective_captures(state)
 
 
-## Thin wrapper — implementation in game/targeting.gd.
-static func _find_adjacent_cell(state: Types.GameState, charger: Types.UnitState, target: Types.UnitState) -> Vector2i:
-	return Targeting.find_adjacent_cell(state, charger, target)

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -20,6 +20,7 @@ extends RefCounted
 const Board = preload("res://game/board.gd")
 const Targeting = preload("res://game/targeting.gd")
 const Combat = preload("res://game/combat.gd")
+const Panic = preload("res://game/panic.gd")
 
 # Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
 # the server still compile during the staged module split.
@@ -1021,209 +1022,26 @@ static func _end_round(state: Types.GameState) -> void:
 # PANIC TEST
 # =============================================================================
 
-## Check whether a unit is currently Fearless (3+ to ignore forced retreat).
-## Sources: "fearless" special rule (Brutes), or "safety_in_numbers" with 8+
-## models alive (Fodder).
+## Thin wrappers — implementations live in game/panic.gd.
 static func _is_fearless(unit: Types.UnitState) -> bool:
-	if "fearless" in unit.special_rules:
-		return true
-	if "safety_in_numbers" in unit.special_rules and unit.model_count >= 8:
-		return true
-	return false
+	return Panic.is_fearless(unit)
 
 
-## Panic test per v17 core p.19.
-## Roll D6 + panic_tokens: ≤6 pass, ≥7 fail (must retreat).
-## Natural 1 always passes. 0 tokens auto-pass (skip test).
-## Fearless units that fail get a second chance: fearless_die 3+ = override to pass.
-##
-## Returns { passed, roll, total, auto_passed, fearless_override, used_fearless }.
-## Does NOT modify unit state — caller applies consequences.
 static func _panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int) -> Dictionary:
-	var result = {
-		"passed": true,
-		"roll": panic_die,
-		"total": 0,
-		"auto_passed": false,
-		"fearless_override": false,
-		"used_fearless": false,
-	}
-
-	# 0 tokens = auto-pass (v17: "units with zero panic tokens can skip the test")
-	if unit.panic_tokens == 0:
-		result["auto_passed"] = true
-		return result
-
-	# Natural 1 always passes
-	if panic_die == 1:
-		return result
-
-	var total: int = panic_die + unit.panic_tokens
-	result["total"] = total
-
-	if total <= 6:
-		# Passed normally
-		return result
-
-	# Failed — check Fearless override
-	if _is_fearless(unit):
-		result["used_fearless"] = true
-		if fearless_die >= 3:
-			result["fearless_override"] = true
-			return result
-
-	result["passed"] = false
-	return result
+	return Panic.panic_test(unit, panic_die, fearless_die)
 
 
 # =============================================================================
 # RETREAT
 # =============================================================================
 
-## Execute retreat for a unit. Mutates state in place.
-## v17 core p.20: move directly away from closest enemy, D6 + 2" per panic
-## token. Board edge = unit destroyed. Stubborn Fanatics never retreat.
-##
-## `retreat_die` is a pre-rolled D6 supplied by the caller (1..6). Pass 1 for
-## the minimum distance when a test intentionally suppresses the D6 component.
-##
-## Returns { retreated, destroyed, from_x, from_y, to_x, to_y, distance,
-##           retreat_die, stubborn_held, no_enemy }.
-## DT tests for crossing Followers deferred to terrain system (#58).
+## Thin wrappers — implementations live in game/panic.gd.
 static func _execute_retreat(state: Types.GameState, unit_id: String, retreat_die: int) -> Dictionary:
-	var unit = _find_unit(state, unit_id)
-	var result = {
-		"retreated": false,
-		"destroyed": false,
-		"from_x": unit.x, "from_y": unit.y,
-		"to_x": unit.x, "to_y": unit.y,
-		"distance": 0,
-		"retreat_die": retreat_die,
-		"stubborn_held": false,
-		"no_enemy": false,
-	}
-
-	if not unit or unit.is_dead:
-		return result
-
-	# Stubborn Fanatics: never retreat (Stump Gun)
-	if "stubborn_fanatics" in unit.special_rules:
-		result["stubborn_held"] = true
-		return result
-
-	# Retreat distance: D6 + 2" per panic token (v17 core p.20).
-	var retreat_dist: int = retreat_die + unit.panic_tokens * 2
-	result["distance"] = retreat_dist
-
-	# Direction: away from nearest alive enemy
-	var nearest_enemy = _find_nearest_enemy(state, unit)
-	if not nearest_enemy:
-		# No enemies alive — nowhere to retreat from. Stay put.
-		result["no_enemy"] = true
-		return result
-
-	var dx: float = float(unit.x - nearest_enemy.x)
-	var dy: float = float(unit.y - nearest_enemy.y)
-	var dist: float = sqrt(dx * dx + dy * dy)
-	if dist < 0.001:
-		# On top of enemy (shouldn't happen). Default retreat direction: toward own deployment zone.
-		dy = 1.0 if unit.owner_seat == 1 else -1.0
-		dx = 0.0
-		dist = 1.0
-
-	# Normalize direction
-	dx /= dist
-	dy /= dist
-
-	# Ideal retreat destination
-	var ideal_x: float = float(unit.x) + dx * float(retreat_dist)
-	var ideal_y: float = float(unit.y) + dy * float(retreat_dist)
-	var target_x: int = clampi(roundi(ideal_x), 0, BOARD_WIDTH - 1)
-	var target_y: int = clampi(roundi(ideal_y), 0, BOARD_HEIGHT - 1)
-
-	# Board edge check: if the ideal position is off the board, unit is destroyed.
-	if roundi(ideal_x) < 0 or roundi(ideal_x) >= BOARD_WIDTH or roundi(ideal_y) < 0 or roundi(ideal_y) >= BOARD_HEIGHT:
-		unit.is_dead = true
-		unit.model_count = 0
-		unit.x = -1
-		unit.y = -1
-		result["retreated"] = true
-		result["destroyed"] = true
-		result["to_x"] = -1
-		result["to_y"] = -1
-		return result
-
-	# Find the best valid cell near the target
-	var dest = _find_retreat_cell(state, unit, target_x, target_y)
-	if dest.x == -1:
-		# No valid cell found — stay in place (edge case, shouldn't normally happen)
-		return result
-
-	unit.x = dest.x
-	unit.y = dest.y
-	result["retreated"] = true
-	result["to_x"] = dest.x
-	result["to_y"] = dest.y
-	return result
+	return Panic.execute_retreat(state, unit_id, retreat_die)
 
 
-## Find the nearest alive enemy unit to the given unit.
 static func _find_nearest_enemy(state: Types.GameState, unit: Types.UnitState) -> Types.UnitState:
-	var best: Types.UnitState = null
-	var best_dist: float = 99999.0
-	for u in state.units:
-		if u.is_dead or u.owner_seat == unit.owner_seat:
-			continue
-		if u.x < 0 or u.y < 0:
-			continue
-		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
-		if d < best_dist:
-			best_dist = d
-			best = u
-	return best
-
-
-## Find a valid retreat destination cell near (target_x, target_y).
-## Searches the target cell first, then spirals outward. Returns Vector2i(-1,-1)
-## if nothing found within a reasonable radius.
-static func _find_retreat_cell(state: Types.GameState, unit: Types.UnitState, target_x: int, target_y: int) -> Vector2i:
-	# Try the ideal cell first
-	if _is_valid_retreat_dest(state, unit, target_x, target_y):
-		return Vector2i(target_x, target_y)
-
-	# Spiral outward looking for an alternative
-	for radius in range(1, 6):
-		var best = Vector2i(-1, -1)
-		var best_dist: float = 99999.0
-		for dy in range(-radius, radius + 1):
-			for dx in range(-radius, radius + 1):
-				if abs(dx) != radius and abs(dy) != radius:
-					continue  # Skip inner cells already checked
-				var cx: int = target_x + dx
-				var cy: int = target_y + dy
-				if _is_valid_retreat_dest(state, unit, cx, cy):
-					var d := _grid_distance(target_x, target_y, cx, cy)
-					if d < best_dist:
-						best_dist = d
-						best = Vector2i(cx, cy)
-		if best.x != -1:
-			return best
-
-	return Vector2i(-1, -1)
-
-
-## Is this cell a valid retreat destination?
-static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> bool:
-	if x < 0 or x >= BOARD_WIDTH or y < 0 or y >= BOARD_HEIGHT:
-		return false
-	# Can't land on an occupied cell
-	for u in state.units:
-		if not u.is_dead and u.id != unit.id and u.x == x and u.y == y:
-			return false
-	# Can't land on an objective (v17 p.22)
-	if _is_objective_at(state, x, y):
-		return false
-	return true
+	return Panic.find_nearest_enemy(state, unit)
 
 
 # =============================================================================

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -292,7 +292,7 @@ static func declare_order(state: Types.GameState, unit_id: String, order_type: S
 	var blundered = false
 	if not ordering_self and blunder_die == 1:
 		blundered = true
-		var new_unit = _find_unit_in(new_state, unit_id)
+		var new_unit = _find_unit(new_state, unit_id)
 		new_unit.panic_tokens = mini(new_unit.panic_tokens + 1, 6)
 
 	new_state.order_phase = "order_execute"
@@ -385,7 +385,7 @@ static func declare_self_order(state: Types.GameState, unit_id: String, order_ty
 	# Always blunder check for self-ordering followers
 	var blundered = (blunder_die == 1)
 	if blundered:
-		var new_unit = _find_unit_in(new_state, unit_id)
+		var new_unit = _find_unit(new_state, unit_id)
 		new_unit.panic_tokens = mini(new_unit.panic_tokens + 1, 6)
 
 	new_state.order_phase = "order_execute"
@@ -508,8 +508,8 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 	var retreat_die: int = params.get("retreat_die", 1)
 
 	var new_state = _clone_state(state)
-	var new_unit = _find_unit_in(new_state, unit.id)
-	var new_target = _find_unit_in(new_state, target_id)
+	var new_unit = _find_unit(new_state, unit.id)
+	var new_target = _find_unit(new_state, target_id)
 
 	var combat = _resolve_shooting_engagement(new_unit, new_target, dice_results, inaccuracy_mod)
 	if combat["error"] != "":
@@ -519,7 +519,7 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 	# Loser retreats (v17 core p.15). Tie → no retreat.
 	var retreat: Dictionary = {}
 	if not combat["tie"] and combat["loser_id"] != "":
-		var loser = _find_unit_in(new_state, combat["loser_id"])
+		var loser = _find_unit(new_state, combat["loser_id"])
 		if loser and not loser.is_dead:
 			retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
 
@@ -601,7 +601,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 		return result
 
 	var new_state = _clone_state(state)
-	var new_unit = _find_unit_in(new_state, unit.id)
+	var new_unit = _find_unit(new_state, unit.id)
 
 	# Move the unit
 	new_unit.x = x
@@ -622,7 +622,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	var fired: bool = false
 	var new_target: Types.UnitState = null
 	if target_id != "":
-		new_target = _find_unit_in(new_state, target_id)
+		new_target = _find_unit(new_state, target_id)
 		if new_target and not new_target.is_dead and new_target.owner_seat != unit.owner_seat:
 			# Validate from post-move position: range + LoS + closest-target
 			var shoot_error = _is_valid_shooting_target_from(new_state, new_unit, new_target, x, y)
@@ -633,7 +633,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 					return result
 				fired = true
 				if not combat["tie"] and combat["loser_id"] != "":
-					var loser = _find_unit_in(new_state, combat["loser_id"])
+					var loser = _find_unit(new_state, combat["loser_id"])
 					if loser and not loser.is_dead:
 						retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
 
@@ -696,7 +696,7 @@ static func _execute_march(state: Types.GameState, unit: Types.UnitState, params
 		return result
 
 	var new_state = _clone_state(state)
-	var new_unit = _find_unit_in(new_state, unit.id)
+	var new_unit = _find_unit(new_state, unit.id)
 	new_unit.x = x
 	new_unit.y = y
 
@@ -783,8 +783,8 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 
 	var new_state = _clone_state(state)
-	var new_unit = _find_unit_in(new_state, unit.id)
-	var new_target = _find_unit_in(new_state, target_id)
+	var new_unit = _find_unit(new_state, unit.id)
+	var new_target = _find_unit(new_state, target_id)
 
 	# v17 core p.16: target takes panic test when charged.
 	var panic_die: int = params.get("panic_die", 1)
@@ -858,7 +858,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	var retreat: Dictionary = {}
 	var charger_retreated: bool = false
 	if not combat["draw"] and combat["loser_id"] != "":
-		var loser = _find_unit_in(new_state, combat["loser_id"])
+		var loser = _find_unit(new_state, combat["loser_id"])
 		if loser and not loser.is_dead:
 			retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
 			if combat["loser_id"] == new_unit.id:
@@ -945,13 +945,13 @@ static func _advance_after_order(state: Types.GameState) -> void:
 	_resolve_objective_captures(state)
 
 	# Mark the ordered unit
-	var unit = _find_unit_in(state, state.current_order_unit_id)
+	var unit = _find_unit(state, state.current_order_unit_id)
 	if unit:
 		unit.has_ordered = true
 
 	# Mark the snob (if one was commanding)
 	if state.current_snob_id != "":
-		var snob = _find_unit_in(state, state.current_snob_id)
+		var snob = _find_unit(state, state.current_snob_id)
 		if snob:
 			snob.has_ordered = true
 
@@ -1089,7 +1089,7 @@ static func _panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int
 ##           retreat_die, stubborn_held, no_enemy }.
 ## DT tests for crossing Followers deferred to terrain system (#58).
 static func _execute_retreat(state: Types.GameState, unit_id: String, retreat_die: int) -> Dictionary:
-	var unit = _find_unit_in(state, unit_id)
+	var unit = _find_unit(state, unit_id)
 	var result = {
 		"retreated": false,
 		"destroyed": false,
@@ -1770,16 +1770,9 @@ static func _clone_state(state: Types.GameState) -> Types.GameState:
 	return Types.GameState.from_dict(state.to_dict())
 
 
-## Find a unit by ID in a GameState (read-only).
+## Find a unit by ID in a GameState. Caller decides whether the returned
+## reference is treated as read-only or as the mutable handle into a cloned state.
 static func _find_unit(state: Types.GameState, unit_id: String) -> Types.UnitState:
-	for u in state.units:
-		if u.id == unit_id:
-			return u
-	return null
-
-
-## Find a unit by ID in a mutable state (for modification after clone).
-static func _find_unit_in(state: Types.GameState, unit_id: String) -> Types.UnitState:
 	for u in state.units:
 		if u.id == unit_id:
 			return u

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -21,6 +21,7 @@ const Board = preload("res://game/board.gd")
 const Targeting = preload("res://game/targeting.gd")
 const Combat = preload("res://game/combat.gd")
 const Panic = preload("res://game/panic.gd")
+const Objectives = preload("res://game/objectives.gd")
 
 # Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
 # the server still compile during the staged module split.
@@ -1094,68 +1095,10 @@ static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, d
 # VICTORY CONDITION
 # =============================================================================
 
-## Check for victory condition.
+## Thin wrapper — implementation in game/objectives.gd. Public (no underscore)
+## because external callers (network_server, victory banner) use the legacy name.
 static func check_victory(state: Types.GameState) -> Dictionary:
-	var units_total_1: int = 0
-	var units_total_2: int = 0
-	var units_alive_1: int = 0
-	var units_alive_2: int = 0
-
-	for unit in state.units:
-		if unit.owner_seat == 1:
-			units_total_1 += 1
-			if not unit.is_dead:
-				units_alive_1 += 1
-		else:
-			units_total_2 += 1
-			if not unit.is_dead:
-				units_alive_2 += 1
-
-	# Solo mode: one side has no units at all — no victory check
-	if units_total_1 == 0 or units_total_2 == 0:
-		return {"winner": 0, "reason": ""}
-
-	if units_alive_1 == 0 and units_alive_2 > 0:
-		return {"winner": 2, "reason": "Player 1 eliminated"}
-	if units_alive_2 == 0 and units_alive_1 > 0:
-		return {"winner": 1, "reason": "Player 2 eliminated"}
-	if units_alive_1 == 0 and units_alive_2 == 0:
-		return {"winner": 0, "reason": "Draw (both eliminated)"}
-
-	# Headless Chicken: all Snobs dead = instant loss
-	var snobs_alive_1 = 0
-	var snobs_alive_2 = 0
-	for unit in state.units:
-		if not unit.is_dead and unit.is_snob():
-			if unit.owner_seat == 1:
-				snobs_alive_1 += 1
-			else:
-				snobs_alive_2 += 1
-
-	if snobs_alive_1 == 0 and snobs_alive_2 > 0:
-		return {"winner": 2, "reason": "Player 1 lost all Snobs (Headless Chicken)"}
-	if snobs_alive_2 == 0 and snobs_alive_1 > 0:
-		return {"winner": 1, "reason": "Player 2 lost all Snobs (Headless Chicken)"}
-
-	# Round limit reached: v17 objective scoring (core p.22, scenarios p.23+).
-	# "The player who controls the most objective markers at the end of the
-	# final round is the victor." Ties go straight to draw — no secondary
-	# model-count fallback in the rules.
-	if state.current_round > state.max_rounds:
-		var objectives_1: int = 0
-		var objectives_2: int = 0
-		for obj in state.objectives:
-			if obj.captured_by == 1:
-				objectives_1 += 1
-			elif obj.captured_by == 2:
-				objectives_2 += 1
-		if objectives_1 > objectives_2:
-			return {"winner": 1, "reason": "Player 1 controls %d objective(s) to %d" % [objectives_1, objectives_2]}
-		if objectives_2 > objectives_1:
-			return {"winner": 2, "reason": "Player 2 controls %d objective(s) to %d" % [objectives_2, objectives_1]}
-		return {"winner": 0, "reason": "Objectives tied %d–%d (Draw)" % [objectives_1, objectives_2]}
-
-	return {"winner": 0, "reason": ""}
+	return Objectives.check_victory(state)
 
 
 # =============================================================================
@@ -1267,54 +1210,13 @@ static func _validate_move(state: Types.GameState, unit: Types.UnitState, x: int
 	return Board.validate_move(state, unit, x, y)
 
 
-## Is there an objective marker at this cell?
+## Thin wrappers — implementations live in game/objectives.gd.
 static func _is_objective_at(state: Types.GameState, x: int, y: int) -> bool:
-	for obj in state.objectives:
-		if obj.x == x and obj.y == y:
-			return true
-	return false
+	return Objectives.is_objective_at(state, x, y)
 
 
-## Recompute capture state for every objective per v17 core p.22.
-## Called after any state change that could shift Follower positions
-## (placement finalized, moves, charges, unit deaths). Mutates in place.
-##
-## Rules modeled:
-##   - Only Follower units capture (Snobs never do).
-##   - "Within 1"" maps to Euclidean distance ≤ 1.0 (orthogonal neighbor).
-##     Diagonal neighbors (√2 ≈ 1.41) are outside 1" and do not capture.
-##   - Objective cell itself is uncapturable-from; units can't end there.
-##   - If only one seat has adjacent Followers → captured by that seat.
-##   - If both seats have adjacent Followers → contested (uncaptured).
-##   - If neither seat has adjacent Followers → retain previous control.
-##
-## MVP simplification: the v17 "only one objective captured per move"
-## player-choice rule is not enforced here — a move that ends adjacent to
-## two uncontrolled objectives will capture both. Tracked for a follow-up
-## when objective placement is dense enough to matter in practice.
 static func _resolve_objective_captures(state: Types.GameState) -> void:
-	for obj in state.objectives:
-		var seat1_adjacent := 0
-		var seat2_adjacent := 0
-		for u in state.units:
-			if u.is_dead or u.is_snob():
-				continue
-			if u.x < 0 or u.y < 0:
-				continue
-			var d := _grid_distance(u.x, u.y, obj.x, obj.y)
-			if d <= 1.0:
-				if u.owner_seat == 1:
-					seat1_adjacent += 1
-				else:
-					seat2_adjacent += 1
-		if seat1_adjacent > 0 and seat2_adjacent > 0:
-			obj.captured_by = 0
-		elif seat1_adjacent > 0:
-			obj.captured_by = 1
-		elif seat2_adjacent > 0:
-			obj.captured_by = 2
-		# else: retain obj.captured_by (captured objective stays captured
-		# until enemy contests or claims it).
+	Objectives.resolve_objective_captures(state)
 
 
 ## Thin wrapper — implementation in game/targeting.gd.

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -500,7 +500,7 @@ static func _execute_volley_fire(state: Types.GameState, unit: Types.UnitState, 
 	if not combat["tie"] and combat["loser_id"] != "":
 		var loser = _find_unit(new_state, combat["loser_id"])
 		if loser and not loser.is_dead:
-			retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
+			retreat = Panic.execute_retreat(new_state, combat["loser_id"], retreat_die)
 
 	_advance_after_order(new_state)
 
@@ -613,7 +613,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 				if not combat["tie"] and combat["loser_id"] != "":
 					var loser = _find_unit(new_state, combat["loser_id"])
 					if loser and not loser.is_dead:
-						retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
+						retreat = Panic.execute_retreat(new_state, combat["loser_id"], retreat_die)
 
 	_advance_after_order(new_state)
 
@@ -765,14 +765,14 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	var panic_die: int = params.get("panic_die", 1)
 	var fearless_die: int = params.get("fearless_die", 1)
 	var retreat_die: int = params.get("retreat_die", 1)
-	var panic = _panic_test(new_target, panic_die, fearless_die)
+	var panic = Panic.panic_test(new_target, panic_die, fearless_die)
 
 	if not panic["passed"]:
 		# Target failed panic test — gains +1 panic token (v17 p.19),
 		# then retreats away from nearest enemy. Charger moves to the
 		# now-vacated adjacent cell. No melee.
 		new_target.panic_tokens = mini(new_target.panic_tokens + 1, 6)
-		var retreat = _execute_retreat(new_state, target_id, retreat_die)
+		var retreat = Panic.execute_retreat(new_state, target_id, retreat_die)
 
 		# Charger advances to adjacent cell (target may have vacated it,
 		# or stayed put if Stubborn Fanatics).
@@ -834,7 +834,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 	if not combat["draw"] and combat["loser_id"] != "":
 		var loser = _find_unit(new_state, combat["loser_id"])
 		if loser and not loser.is_dead:
-			retreat = _execute_retreat(new_state, combat["loser_id"], retreat_die)
+			retreat = Panic.execute_retreat(new_state, combat["loser_id"], retreat_die)
 			if combat["loser_id"] == new_unit.id:
 				charger_retreated = true
 
@@ -986,32 +986,6 @@ static func _end_round(state: Types.GameState) -> void:
 		"round": state.current_round - 1,
 		"action": "round_ended"
 	})
-
-
-# =============================================================================
-# PANIC TEST
-# =============================================================================
-
-## Thin wrappers — implementations live in game/panic.gd.
-static func _is_fearless(unit: Types.UnitState) -> bool:
-	return Panic.is_fearless(unit)
-
-
-static func _panic_test(unit: Types.UnitState, panic_die: int, fearless_die: int) -> Dictionary:
-	return Panic.panic_test(unit, panic_die, fearless_die)
-
-
-# =============================================================================
-# RETREAT
-# =============================================================================
-
-## Thin wrappers — implementations live in game/panic.gd.
-static func _execute_retreat(state: Types.GameState, unit_id: String, retreat_die: int) -> Dictionary:
-	return Panic.execute_retreat(state, unit_id, retreat_die)
-
-
-static func _find_nearest_enemy(state: Types.GameState, unit: Types.UnitState) -> Types.UnitState:
-	return Panic.find_nearest_enemy(state, unit)
 
 
 # =============================================================================

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -23,24 +23,9 @@ const Combat = preload("res://game/combat.gd")
 const Panic = preload("res://game/panic.gd")
 const Objectives = preload("res://game/objectives.gd")
 
-# Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
-# the server still compile during the staged module split.
-const BOARD_WIDTH: int = Board.BOARD_WIDTH
-const BOARD_HEIGHT: int = Board.BOARD_HEIGHT
-const DEPLOYMENT_ZONE_1_Y_MIN: int = Board.DEPLOYMENT_ZONE_1_Y_MIN
-const DEPLOYMENT_ZONE_1_Y_MAX: int = Board.DEPLOYMENT_ZONE_1_Y_MAX
-const DEPLOYMENT_ZONE_2_Y_MIN: int = Board.DEPLOYMENT_ZONE_2_Y_MIN
-const DEPLOYMENT_ZONE_2_Y_MAX: int = Board.DEPLOYMENT_ZONE_2_Y_MAX
-
 # Re-exported so existing GameEngine.MELEE_MAX_BOUTS callers compile.
 # Authoritative definition lives in game/combat.gd.
 const MELEE_MAX_BOUTS: int = Combat.MELEE_MAX_BOUTS
-
-
-## Thin wrapper for the few in-engine callers that still use the legacy name.
-## Removed in a follow-up once all callers move to Board.grid_distance directly.
-static func _grid_distance(x1: int, y1: int, x2: int, y2: int) -> float:
-	return Board.grid_distance(x1, y1, x2, y2)
 
 
 # =============================================================================
@@ -73,16 +58,16 @@ static func place_unit(state: Types.GameState, unit_id: String, x: int, y: int) 
 		result.error = "Unit already placed"
 		return result
 
-	if x < 0 or x >= BOARD_WIDTH or y < 0 or y >= BOARD_HEIGHT:
+	if x < 0 or x >= Board.BOARD_WIDTH or y < 0 or y >= Board.BOARD_HEIGHT:
 		result.error = "Coordinates out of bounds"
 		return result
 
 	var valid_zone: bool = false
 	if state.active_seat == 1:
-		if y >= DEPLOYMENT_ZONE_1_Y_MIN and y <= DEPLOYMENT_ZONE_1_Y_MAX:
+		if y >= Board.DEPLOYMENT_ZONE_1_Y_MIN and y <= Board.DEPLOYMENT_ZONE_1_Y_MAX:
 			valid_zone = true
 	else:
-		if y >= DEPLOYMENT_ZONE_2_Y_MIN and y <= DEPLOYMENT_ZONE_2_Y_MAX:
+		if y >= Board.DEPLOYMENT_ZONE_2_Y_MIN and y <= Board.DEPLOYMENT_ZONE_2_Y_MAX:
 			valid_zone = true
 
 	if not valid_zone:
@@ -260,7 +245,7 @@ static func declare_order(state: Types.GameState, unit_id: String, order_type: S
 		if unit.is_snob():
 			result.error = "Cannot order another Snob"
 			return result
-		var distance = _grid_distance(snob.x, snob.y, unit.x, unit.y)
+		var distance = Board.grid_distance(snob.x, snob.y, unit.x, unit.y)
 		if distance > snob.get_command_range():
 			result.error = "Unit out of command range (%.1f > %d)" % [distance, snob.get_command_range()]
 			return result
@@ -583,7 +568,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	var target_id = params.get("target_id", "")
 
 	# Movement validation
-	var move_error = _validate_move(state, unit, x, y)
+	var move_error = Board.validate_move(state, unit, x, y)
 	if move_error != "":
 		result.error = move_error
 		return result
@@ -592,7 +577,7 @@ static func _execute_move_and_shoot(state: Types.GameState, unit: Types.UnitStat
 	var max_move = unit.base_stats.movement
 	if state.current_order_blundered:
 		max_move = state.current_order_move_bonus  # D6 result stored during declare
-	var distance = _grid_distance(unit.x, unit.y, x, y)
+	var distance = Board.grid_distance(unit.x, unit.y, x, y)
 	if distance > max_move:
 		result.error = "Out of movement range (max %d)" % max_move
 		return result
@@ -679,14 +664,14 @@ static func _execute_march(state: Types.GameState, unit: Types.UnitState, params
 	var x = params.get("x", -1)
 	var y = params.get("y", -1)
 
-	var move_error = _validate_move(state, unit, x, y)
+	var move_error = Board.validate_move(state, unit, x, y)
 	if move_error != "":
 		result.error = move_error
 		return result
 
 	# March range: M + move_bonus (2D6 or 1D6 if blundered)
 	var max_move = unit.base_stats.movement + state.current_order_move_bonus
-	var distance = _grid_distance(unit.x, unit.y, x, y)
+	var distance = Board.grid_distance(unit.x, unit.y, x, y)
 	if distance > max_move:
 		result.error = "Out of march range (max %d = M%d + %d)" % [max_move, unit.base_stats.movement, state.current_order_move_bonus]
 		return result
@@ -759,7 +744,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 
 	# Charge range: M + move_bonus. Must end adjacent (distance = 1) to target.
 	var charge_range = unit.base_stats.movement + state.current_order_move_bonus
-	var target_distance = _grid_distance(unit.x, unit.y, target.x, target.y)
+	var target_distance = Board.grid_distance(unit.x, unit.y, target.x, target.y)
 	if target_distance > charge_range:
 		result.error = "Target out of charge range (distance %.1f, max %d)" % [target_distance, charge_range]
 		return result
@@ -771,7 +756,7 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		return result
 
 	# Verify the adjacent cell is within charge range
-	var move_distance = _grid_distance(unit.x, unit.y, charge_dest.x, charge_dest.y)
+	var move_distance = Board.grid_distance(unit.x, unit.y, charge_dest.x, charge_dest.y)
 	if move_distance > charge_range:
 		result.error = "Cannot reach target (need %.1f, have %d)" % [move_distance, charge_range]
 		return result
@@ -1159,7 +1144,7 @@ static func _has_valid_charge_target(state: Types.GameState, unit: Types.UnitSta
 	for u in state.units:
 		if u.is_dead or u.owner_seat == unit.owner_seat:
 			continue
-		var d := _grid_distance(unit.x, unit.y, u.x, u.y)
+		var d := Board.grid_distance(unit.x, unit.y, u.x, u.y)
 		if d <= reach and _has_line_of_sight(state, unit.x, unit.y, u.x, u.y):
 			return true
 	return false
@@ -1184,18 +1169,11 @@ static func get_followers_in_command_range(state: Types.GameState, snob_id: Stri
 
 	for unit in state.units:
 		if unit.owner_seat == snob.owner_seat and not unit.is_snob() and not unit.is_dead and not unit.has_ordered:
-			var distance = _grid_distance(snob.x, snob.y, unit.x, unit.y)
+			var distance = Board.grid_distance(snob.x, snob.y, unit.x, unit.y)
 			if distance <= cmd_range:
 				result.append(unit.id)
 
 	return result
-
-
-## Thin wrapper retained so internal call sites still compile after the
-## board.gd extraction. Removed in a follow-up once callers move to
-## Board.validate_move directly.
-static func _validate_move(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> String:
-	return Board.validate_move(state, unit, x, y)
 
 
 ## Thin wrappers — implementations live in game/objectives.gd.

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -14,12 +14,12 @@ extends RefCounted
 ##   5. After all Snobs ordered, unordered Followers order themselves
 ##   6. Round ends, advance to next round
 
-# Board geometry, distance, and move validation live in game/board.gd.
-# Targeting (LoS, valid-target enumeration, charge contact) lives in
-# game/targeting.gd. Preloaded (not class_name) so headless test runs
-# don't depend on the global script class cache being up to date.
+# Pure logic modules — all live under game/, all RefCounted, all preloaded
+# (not just class_name) so headless test runs don't depend on the global
+# script class cache being up to date.
 const Board = preload("res://game/board.gd")
 const Targeting = preload("res://game/targeting.gd")
+const Combat = preload("res://game/combat.gd")
 
 # Re-exported constants so existing GameEngine.BOARD_WIDTH etc. callers in
 # the server still compile during the staged module split.
@@ -30,10 +30,9 @@ const DEPLOYMENT_ZONE_1_Y_MAX: int = Board.DEPLOYMENT_ZONE_1_Y_MAX
 const DEPLOYMENT_ZONE_2_Y_MIN: int = Board.DEPLOYMENT_ZONE_2_Y_MIN
 const DEPLOYMENT_ZONE_2_Y_MAX: int = Board.DEPLOYMENT_ZONE_2_Y_MAX
 
-# Melee bout cap — v17 has no hard limit, but tied bouts could loop forever on
-# whiffing dice. Cap at 3; unresolved ties after the cap end in a draw with no
-# retreat (both sides still take +1 panic per melee-ended rule).
-const MELEE_MAX_BOUTS: int = 3
+# Re-exported so existing GameEngine.MELEE_MAX_BOUTS callers compile.
+# Authoritative definition lives in game/combat.gd.
+const MELEE_MAX_BOUTS: int = Combat.MELEE_MAX_BOUTS
 
 
 ## Thin wrapper for the few in-engine callers that still use the legacy name.
@@ -1231,55 +1230,13 @@ static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState
 # COMBAT RESOLUTION HELPERS
 # =============================================================================
 
-## Resolve one side's shooting attacks. Consumes dice from the pool starting
-## at `offset`. Does NOT mutate either unit — caller applies wounds, smoke,
-## and panic tokens after both sides have rolled. Returns
-## { hits, saves, unsaved_wounds, dice_used, error }.
+## Thin wrappers — implementations live in game/combat.gd.
 static func _resolve_shooting_side(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, offset: int, inaccuracy_mod: int) -> Dictionary:
-	var num_attacks = attacker.model_count
-	var needed_dice = num_attacks * 2
-	if dice_results.size() - offset < needed_dice:
-		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
-				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
-
-	var inaccuracy = maxi(attacker.base_stats.inaccuracy + inaccuracy_mod, 2)
-	var vulnerability = target.base_stats.vulnerability
-
-	# Equipment modifiers
-	if attacker.equipment == "missile":
-		vulnerability = maxi(vulnerability - 2, 2)
-
-	var hits = 0
-	var saves = 0
-	var unsaved_wounds = 0
-
-	for i in range(num_attacks):
-		var inac_roll = dice_results[offset + i]
-		var vuln_roll = dice_results[offset + num_attacks + i]
-		if inac_roll >= inaccuracy:
-			hits += 1
-			if vuln_roll >= vulnerability:
-				saves += 1
-			else:
-				unsaved_wounds += 1
-
-	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
-			"dice_used": needed_dice, "error": ""}
+	return Combat.resolve_shooting_side(attacker, target, dice_results, offset, inaccuracy_mod)
 
 
-## Is the target eligible to return fire at the shooter? v17 core p.13:
-## target must have a ranged weapon, no powder smoke, and the shooter must
-## be within the target's weapon range. Casualties from the primary strike
-## do NOT suppress return fire (resolved from pre-engagement state).
 static func _can_return_fire(target: Types.UnitState, shooter: Types.UnitState) -> bool:
-	if target.is_dead or shooter.is_dead:
-		return false
-	if target.base_stats.weapon_range <= 0:
-		return false
-	if target.has_powder_smoke:
-		return false
-	var dist := _grid_distance(target.x, target.y, shooter.x, shooter.y)
-	return dist <= target.base_stats.weapon_range
+	return Combat.can_return_fire(target, shooter)
 
 
 ## Resolve a shooting engagement (v17 core p.13). Both sides roll against
@@ -1300,215 +1257,19 @@ static func _can_return_fire(target: Types.UnitState, shooter: Types.UnitState) 
 ##   error: String
 ## }
 static func _resolve_shooting_engagement(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array, attacker_inaccuracy_mod: int) -> Dictionary:
-	var result = {
-		"att_hits": 0, "att_saves": 0, "att_wounds": 0,
-		"def_hits": 0, "def_saves": 0, "def_wounds": 0,
-		"return_fire_fired": false,
-		"winner_id": "", "loser_id": "",
-		"tie": false,
-		"dice_used": 0,
-		"error": "",
-	}
-
-	if attacker.is_dead or target.is_dead:
-		result["error"] = "Cannot resolve shooting: one side already dead"
-		return result
-
-	# Attacker rolls first (dice pool laid out attacker-then-defender).
-	var att = _resolve_shooting_side(attacker, target, dice_results, 0, attacker_inaccuracy_mod)
-	if att["error"] != "":
-		result["error"] = att["error"]
-		return result
-	result["att_hits"] = att["hits"]
-	result["att_saves"] = att["saves"]
-	result["att_wounds"] = att["unsaved_wounds"]
-
-	var offset: int = att["dice_used"]
-
-	# Return fire eligibility checked from pre-engagement state.
-	var can_return = _can_return_fire(target, attacker)
-	if can_return:
-		# Defender return fire — inaccuracy_mod=0 (no volley-fire bonus on return).
-		var defn = _resolve_shooting_side(target, attacker, dice_results, offset, 0)
-		if defn["error"] != "":
-			result["error"] = defn["error"]
-			return result
-		result["def_hits"] = defn["hits"]
-		result["def_saves"] = defn["saves"]
-		result["def_wounds"] = defn["unsaved_wounds"]
-		result["return_fire_fired"] = true
-		offset += defn["dice_used"]
-
-	result["dice_used"] = offset
-
-	# Apply wounds simultaneously (casualties don't suppress return fire).
-	_apply_wounds(target, result["att_wounds"])
-	if result["return_fire_fired"]:
-		_apply_wounds(attacker, result["def_wounds"])
-
-	# Panic tokens from taking hits (any hits, saved or not).
-	if result["att_hits"] > 0 and not target.is_dead:
-		target.panic_tokens = mini(target.panic_tokens + 1, 6)
-	if result["def_hits"] > 0 and not attacker.is_dead:
-		attacker.panic_tokens = mini(attacker.panic_tokens + 1, 6)
-
-	# Powder smoke: whichever side fired with black_powder gets a smoke token.
-	if attacker.equipment == "black_powder":
-		attacker.has_powder_smoke = true
-	if result["return_fire_fired"] and target.equipment == "black_powder":
-		target.has_powder_smoke = true
-
-	# Winner / loser / tie — decided by total unsaved wounds dealt.
-	if result["att_wounds"] > result["def_wounds"]:
-		result["winner_id"] = attacker.id
-		result["loser_id"] = target.id
-	elif result["def_wounds"] > result["att_wounds"]:
-		result["winner_id"] = target.id
-		result["loser_id"] = attacker.id
-	else:
-		result["tie"] = true
-
-	return result
+	return Combat.resolve_shooting_engagement(attacker, target, dice_results, attacker_inaccuracy_mod)
 
 
-## Resolve one side's attacks in a melee bout. Consumes dice from the pool
-## starting at `offset`. Returns { hits, saves, unsaved_wounds, dice_used, error }.
-## Mutates `defender` via _apply_wounds.
 static func _resolve_bout_side(attacker: Types.UnitState, defender: Types.UnitState, dice_results: Array, offset: int) -> Dictionary:
-	var attacks_per_model = attacker.base_stats.attacks
-	var inaccuracy = attacker.base_stats.inaccuracy
-	var vulnerability = defender.base_stats.vulnerability
-
-	# Close combat equipment reduces inaccuracy by 1 (min 2)
-	if attacker.equipment == "close_combat":
-		inaccuracy = maxi(inaccuracy - 1, 2)
-
-	var num_attacks = attacker.model_count * attacks_per_model
-	var needed_dice = num_attacks * 2
-	if dice_results.size() - offset < needed_dice:
-		return {"hits": 0, "saves": 0, "unsaved_wounds": 0, "dice_used": 0,
-				"error": "Not enough dice (need %d at offset %d, have %d)" % [needed_dice, offset, dice_results.size() - offset]}
-
-	var hits = 0
-	var saves = 0
-	var unsaved_wounds = 0
-
-	for i in range(num_attacks):
-		var inac_roll = dice_results[offset + i]
-		var vuln_roll = dice_results[offset + num_attacks + i]
-		if inac_roll >= inaccuracy:
-			hits += 1
-			if vuln_roll >= vulnerability:
-				saves += 1
-			else:
-				unsaved_wounds += 1
-
-	_apply_wounds(defender, unsaved_wounds)
-
-	return {"hits": hits, "saves": saves, "unsaved_wounds": unsaved_wounds,
-			"dice_used": needed_dice, "error": ""}
+	return Combat.resolve_bout_side(attacker, defender, dice_results, offset)
 
 
-## Worst-case dice pool size for a full melee between two units.
-## Attacker strikes + defender counter-strikes, each at 2 dice per attack,
-## across up to MELEE_MAX_BOUTS. Callers should supply at least this many.
 static func _melee_dice_budget(attacker: Types.UnitState, defender: Types.UnitState) -> int:
-	var per_bout = (attacker.model_count * attacker.base_stats.attacks * 2) \
-		+ (defender.model_count * defender.base_stats.attacks * 2)
-	return per_bout * MELEE_MAX_BOUTS
+	return Combat.melee_dice_budget(attacker, defender)
 
 
-## Resolve a melee engagement as bouts (v17 core p.18). Mutates both units
-## in place via wound application. Does NOT apply post-melee panic tokens or
-## trigger retreat — caller handles those so it can integrate with state.
-##
-## Each bout: attacker strikes → defender removes casualties → if defender
-## still alive, defender counter-strikes → attacker removes casualties.
-## Winner = side that dealt more unsaved wounds that bout. Tie → next bout.
-## Hard cap at MELEE_MAX_BOUTS; if still tied at the cap, draw (no retreat).
-##
-## Returns {
-##   bouts: [{atk_hits, atk_saves, atk_wounds, def_hits, def_saves, def_wounds}...],
-##   winner_id, loser_id,  # "" on draw or if one side was already dead
-##   draw: bool,           # true only when cap hit with no winner
-##   dice_used: int,
-##   error: String
-## }
 static func _resolve_melee(attacker: Types.UnitState, target: Types.UnitState, dice_results: Array) -> Dictionary:
-	var summary = {
-		"bouts": [],
-		"winner_id": "",
-		"loser_id": "",
-		"draw": false,
-		"dice_used": 0,
-		"error": "",
-	}
-
-	if attacker.is_dead or target.is_dead:
-		summary["error"] = "Cannot resolve melee: one side already dead"
-		return summary
-
-	var offset: int = 0
-
-	for bout_idx in range(MELEE_MAX_BOUTS):
-		var bout = {
-			"atk_hits": 0, "atk_saves": 0, "atk_wounds": 0,
-			"def_hits": 0, "def_saves": 0, "def_wounds": 0,
-		}
-
-		# Attacker strikes first
-		var atk = _resolve_bout_side(attacker, target, dice_results, offset)
-		if atk["error"] != "":
-			summary["error"] = atk["error"]
-			return summary
-		offset += atk["dice_used"]
-		bout["atk_hits"] = atk["hits"]
-		bout["atk_saves"] = atk["saves"]
-		bout["atk_wounds"] = atk["unsaved_wounds"]
-
-		# Target wiped out before counter-attack
-		if target.is_dead:
-			summary["bouts"].append(bout)
-			summary["winner_id"] = attacker.id
-			summary["loser_id"] = target.id
-			summary["dice_used"] = offset
-			return summary
-
-		# Defender counter-strikes
-		var def = _resolve_bout_side(target, attacker, dice_results, offset)
-		if def["error"] != "":
-			summary["error"] = def["error"]
-			return summary
-		offset += def["dice_used"]
-		bout["def_hits"] = def["hits"]
-		bout["def_saves"] = def["saves"]
-		bout["def_wounds"] = def["unsaved_wounds"]
-		summary["bouts"].append(bout)
-
-		# Attacker wiped out — defender wins the bout trivially
-		if attacker.is_dead:
-			summary["winner_id"] = target.id
-			summary["loser_id"] = attacker.id
-			summary["dice_used"] = offset
-			return summary
-
-		# Both alive — decide the bout
-		if bout["atk_wounds"] > bout["def_wounds"]:
-			summary["winner_id"] = attacker.id
-			summary["loser_id"] = target.id
-			summary["dice_used"] = offset
-			return summary
-		if bout["def_wounds"] > bout["atk_wounds"]:
-			summary["winner_id"] = target.id
-			summary["loser_id"] = attacker.id
-			summary["dice_used"] = offset
-			return summary
-		# Tie → next bout
-
-	# Cap reached with no decisive bout — draw.
-	summary["draw"] = true
-	summary["dice_used"] = offset
-	return summary
+	return Combat.resolve_melee(attacker, target, dice_results)
 
 
 # =============================================================================
@@ -1609,18 +1370,9 @@ static func _is_valid_shooting_target_from(state: Types.GameState, shooter: Type
 # HELPER FUNCTIONS
 # =============================================================================
 
-## Apply wounds to a unit, removing models as they die.
+## Thin wrapper — implementation in game/combat.gd.
 static func _apply_wounds(unit: Types.UnitState, wounds: int) -> void:
-	var remaining_wounds = wounds
-	while remaining_wounds > 0 and not unit.is_dead:
-		unit.current_wounds += 1
-		remaining_wounds -= 1
-		if unit.current_wounds >= unit.base_stats.wounds:
-			unit.model_count -= 1
-			unit.current_wounds = 0
-			if unit.model_count <= 0:
-				unit.is_dead = true
-				unit.model_count = 0
+	Combat.apply_wounds(unit, wounds)
 
 
 ## Deep clone a GameState.

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -308,7 +308,7 @@ func request_action(action_data: Dictionary) -> void:
 			_send_error_to_client(peer_id, "Unknown action type: " + action_type)
 			return
 
-	if not result.success:
+	if not result.is_success():
 		_send_error_to_client(peer_id, result.error)
 		return
 

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -2,6 +2,9 @@ extends Node
 ## ENet server listener — Phase 3 + 4.
 ## Exposes RPCs for clients to interact with the server.
 
+const Combat = preload("res://game/combat.gd")
+const Objectives = preload("res://game/objectives.gd")
+
 @onready var room_manager: Node = get_parent().get_node("RoomManager")
 
 # Active game states: room_code -> Types.GameState
@@ -358,7 +361,7 @@ func _roll_d6() -> int:
 
 ## Helper: Roll the combat dice pool an execute_order requires, sized to the
 ## ordered unit and the declared order type. Charge sizing accounts for the
-## full melee: both sides strike per bout, up to GameEngine.MELEE_MAX_BOUTS.
+## full melee: both sides strike per bout, up to Combat.MELEE_MAX_BOUTS.
 func _roll_execute_dice(state: Types.GameState, params: Dictionary) -> Array:
 	var unit = _find_unit(state, state.current_order_unit_id)
 	if unit == null:
@@ -384,7 +387,7 @@ func _roll_execute_dice(state: Types.GameState, params: Dictionary) -> Array:
 			var target = _find_unit(state, params.get("target_id", ""))
 			if target != null:
 				def_per_bout = target.model_count * target.base_stats.attacks * 2
-			num_dice = (atk_per_bout + def_per_bout) * GameEngine.MELEE_MAX_BOUTS
+			num_dice = (atk_per_bout + def_per_bout) * Combat.MELEE_MAX_BOUTS
 		"march":
 			num_dice = 0
 

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -319,7 +319,7 @@ func request_action(action_data: Dictionary) -> void:
 	active_games[room.code] = result.new_state
 
 	# Check victory (also handles max-rounds tiebreak / draw)
-	var victory = GameEngine.check_victory(result.new_state)
+	var victory = Objectives.check_victory(result.new_state)
 	var game_over: bool = victory["winner"] != 0 or result.new_state.phase == "finished"
 	if game_over:
 		result.new_state.phase = "finished"

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -57,7 +57,7 @@ func _test_placement_phase() -> void:
 
 		var result = GameEngine.place_unit(state, unit.id, 10, 30)
 
-		return result.success and result.new_state.units[0].x == 10 and result.new_state.units[0].y == 30
+		return result.is_success() and result.new_state.units[0].x == 10 and result.new_state.units[0].y == 30
 	)
 
 	_test("Reject placement outside deployment zone", func():
@@ -66,7 +66,7 @@ func _test_placement_phase() -> void:
 
 		var result = GameEngine.place_unit(state, unit.id, 10, 15)
 
-		return not result.success and "deployment zone" in result.error
+		return not result.is_success() and "deployment zone" in result.error
 	)
 
 	_test("Reject placement on occupied position", func():
@@ -78,7 +78,7 @@ func _test_placement_phase() -> void:
 
 		var result = GameEngine.place_unit(state, state.units[3].id, 10, 2)
 
-		return not result.success and "occupied" in result.error
+		return not result.is_success() and "occupied" in result.error
 	)
 
 	_test("Confirm placement starts orders when both done", func():
@@ -86,7 +86,7 @@ func _test_placement_phase() -> void:
 
 		var result = GameEngine.confirm_placement(state)
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.phase == "orders"
 			and result.new_state.order_phase == "snob_select")
 	)
@@ -99,7 +99,7 @@ func _test_snob_selection() -> void:
 		var state = _mock_orders_state()
 		var result = GameEngine.select_snob(state, state.units[0].id)
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.order_phase == "order_declare"
 			and result.new_state.current_snob_id == state.units[0].id)
 	)
@@ -108,14 +108,14 @@ func _test_snob_selection() -> void:
 		var state = _mock_orders_state()
 		var result = GameEngine.select_snob(state, state.units[2].id)
 
-		return not result.success and "not a Snob" in result.error
+		return not result.is_success() and "not a Snob" in result.error
 	)
 
 	_test("select_snob: reject enemy Snob", func():
 		var state = _mock_orders_state()
 		var result = GameEngine.select_snob(state, state.units[1].id)
 
-		return not result.success and "Not your Snob" in result.error
+		return not result.is_success() and "Not your Snob" in result.error
 	)
 
 	_test("select_snob: reject already-ordered Snob", func():
@@ -124,7 +124,7 @@ func _test_snob_selection() -> void:
 
 		var result = GameEngine.select_snob(state, state.units[0].id)
 
-		return not result.success and "already ordered" in result.error
+		return not result.is_success() and "already ordered" in result.error
 	)
 
 	_test("select_snob: reject outside snob_select phase", func():
@@ -133,7 +133,7 @@ func _test_snob_selection() -> void:
 
 		var result = GameEngine.select_snob(state, state.units[0].id)
 
-		return not result.success and "snob selection" in result.error
+		return not result.is_success() and "snob selection" in result.error
 	)
 
 
@@ -146,7 +146,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "march", 3, [3, 4])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.order_phase == "order_execute"
 			and result.new_state.current_order_type == "march"
 			and result.new_state.current_order_move_bonus == 7)  # 3+4 unblundered
@@ -160,7 +160,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "march", 3, [3, 3])
 
-		return not result.success and "command range" in result.error
+		return not result.is_success() and "command range" in result.error
 	)
 
 	_test("declare_order: diagonal follower within Euclidean command range succeeds", func():
@@ -173,7 +173,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "march", 3, [3, 3])
 
-		return result.success
+		return result.is_success()
 	)
 
 	_test("declare_order: Snob self-order bypasses blunder check", func():
@@ -183,7 +183,7 @@ func _test_declare_order() -> void:
 		# blunder_die=1 normally blunders, but self-order never blunders
 		var result = GameEngine.declare_order(state, state.units[0].id, "march", 1, [3, 3])
 
-		return (result.success
+		return (result.is_success()
 			and not result.new_state.current_order_blundered
 			and result.new_state.units[0].panic_tokens == 0)
 	)
@@ -194,7 +194,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "march", 1, [4, 5])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.current_order_blundered
 			and result.new_state.units[2].panic_tokens == 1
 			and result.new_state.current_order_move_bonus == 4)  # only first die
@@ -207,7 +207,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "volley_fire", 3, [3, 3])
 
-		return not result.success and "ranged weapon" in result.error
+		return not result.is_success() and "ranged weapon" in result.error
 	)
 
 	_test("declare_order: reject volley_fire with powder smoke", func():
@@ -218,7 +218,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "volley_fire", 3, [3, 3])
 
-		return not result.success and "powder smoke" in result.error
+		return not result.is_success() and "powder smoke" in result.error
 	)
 
 	_test("declare_order: reject ordering another Snob", func():
@@ -231,7 +231,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, u4.id, "march", 3, [3, 3])
 
-		return not result.success and "another Snob" in result.error
+		return not result.is_success() and "another Snob" in result.error
 	)
 
 	_test("declare_order: reject invalid order type", func():
@@ -240,7 +240,7 @@ func _test_declare_order() -> void:
 
 		var result = GameEngine.declare_order(state, state.units[2].id, "teleport", 3, [3, 3])
 
-		return not result.success and "Invalid order type" in result.error
+		return not result.is_success() and "Invalid order type" in result.error
 	)
 
 
@@ -251,7 +251,7 @@ func _test_declare_self_order() -> void:
 		var state = _mock_orders_state_follower_phase()
 		var result = GameEngine.declare_self_order(state, state.units[2].id, "march", 3, [3, 4])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.order_phase == "order_execute"
 			and result.new_state.current_order_unit_id == state.units[2].id
 			and result.new_state.current_snob_id == ""
@@ -262,7 +262,7 @@ func _test_declare_self_order() -> void:
 		var state = _mock_orders_state_follower_phase()
 		var result = GameEngine.declare_self_order(state, state.units[2].id, "march", 1, [4, 5])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.current_order_blundered
 			and result.new_state.units[2].panic_tokens == 1
 			and result.new_state.current_order_move_bonus == 4)
@@ -274,7 +274,7 @@ func _test_declare_self_order() -> void:
 
 		var result = GameEngine.declare_self_order(state, state.units[0].id, "march", 3, [3, 3])
 
-		return not result.success and "Snobs don't self-order" in result.error
+		return not result.is_success() and "Snobs don't self-order" in result.error
 	)
 
 	_test("declare_self_order: reject outside follower_self_order phase", func():
@@ -282,7 +282,7 @@ func _test_declare_self_order() -> void:
 		# phase is snob_select, not follower_self_order
 		var result = GameEngine.declare_self_order(state, state.units[2].id, "march", 3, [3, 3])
 
-		return not result.success and "follower self-order" in result.error
+		return not result.is_success() and "follower self-order" in result.error
 	)
 
 
@@ -300,7 +300,7 @@ func _test_execute_volley_fire() -> void:
 		# both whiff → 0 shooter wounds.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 1, 1, 1])
 
-		return result.success and result.new_state.units[1].current_wounds == 1
+		return result.is_success() and result.new_state.units[1].current_wounds == 1
 	)
 
 	_test("volley_fire: unblundered roll that barely misses without bonus still hits", func():
@@ -312,7 +312,7 @@ func _test_execute_volley_fire() -> void:
 		# Return fire: 2 dice of 1 → miss, no shooter wounds.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6, 1, 1])
 
-		return result.success and result.new_state.units[1].current_wounds == 0  # saved
+		return result.is_success() and result.new_state.units[1].current_wounds == 0  # saved
 	)
 
 	_test("volley_fire: blundered loses -1 bonus", func():
@@ -329,7 +329,7 @@ func _test_execute_volley_fire() -> void:
 		# Return fire from Toff u1: 2 dice → 1s miss.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 1, 1, 1])
 
-		return result.success and result.new_state.units[1].current_wounds == 0
+		return result.is_success() and result.new_state.units[1].current_wounds == 0
 	)
 
 	_test("volley_fire: black_powder grants powder smoke after firing", func():
@@ -341,7 +341,7 @@ func _test_execute_volley_fire() -> void:
 		# Shooter miss (3 at I4+), return fire 2 dice of 1 → miss.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [3, 1, 1, 1])
 
-		return result.success and result.new_state.units[0].has_powder_smoke
+		return result.is_success() and result.new_state.units[0].has_powder_smoke
 	)
 
 	_test("volley_fire: hit grants target a panic token", func():
@@ -353,7 +353,7 @@ func _test_execute_volley_fire() -> void:
 		# Return fire: 2 dice of 1 → miss (no extra panic flow).
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [4, 6, 1, 1])
 
-		return result.success and result.new_state.units[1].panic_tokens == 1
+		return result.is_success() and result.new_state.units[1].panic_tokens == 1
 	)
 
 	_test("volley_fire: fizzle succeeds when no enemy in range", func():
@@ -364,7 +364,7 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].has_ordered
 			and result.new_state.units[1].current_wounds == 0)
 	)
@@ -376,7 +376,7 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
-		return not result.success and "Cannot fizzle" in result.error
+		return not result.is_success() and "Cannot fizzle" in result.error
 	)
 
 	_test("volley_fire: diagonal target within Euclidean range is valid", func():
@@ -392,7 +392,7 @@ func _test_execute_volley_fire() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1])
-		return result.success
+		return result.is_success()
 	)
 
 	_test("volley_fire: multi-model unit fires one attack per model", func():
@@ -412,7 +412,7 @@ func _test_execute_volley_fire() -> void:
 		var dice = [5, 5, 5, 5, 1, 1, 1, 1, 1, 1]
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, dice)
 
-		return result.success and result.new_state.units[1].is_dead
+		return result.is_success() and result.new_state.units[1].is_dead
 	)
 
 
@@ -430,7 +430,7 @@ func _test_execute_move_and_shoot() -> void:
 		var params = {"x": 12, "y": 15, "target_id": state.units[1].id}
 		var result = GameEngine.execute_order(state, params, [5, 1, 1, 1])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 12
 			and result.new_state.units[1].current_wounds == 1)
 	)
@@ -443,7 +443,7 @@ func _test_execute_move_and_shoot() -> void:
 		# Just move, no shot (no target_id)
 		var result = GameEngine.execute_order(state, {"x": 13, "y": 15}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 13
 			and result.new_state.units[1].current_wounds == 0)
 	)
@@ -462,7 +462,7 @@ func _test_execute_move_and_shoot() -> void:
 		# (15, 15) from (12, 15) = distance 3. Exactly at the blundered cap.
 		var result = GameEngine.execute_order(state, {"x": 15, "y": 15}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[2].x == 15
 			and result.new_state.units[2].y == 15)
 	)
@@ -480,7 +480,7 @@ func _test_execute_move_and_shoot() -> void:
 		# Distance 3 > 2 → rejected
 		var result = GameEngine.execute_order(state, {"x": 15, "y": 15}, [])
 
-		return not result.success and "movement range" in result.error
+		return not result.is_success() and "movement range" in result.error
 	)
 
 	_test("move_and_shoot: reject move beyond M", func():
@@ -491,7 +491,7 @@ func _test_execute_move_and_shoot() -> void:
 		# Toff M=6, from (10,15). (17,15) is distance 7 > 6 and unoccupied.
 		var result = GameEngine.execute_order(state, {"x": 17, "y": 15}, [])
 
-		return not result.success and "movement range" in result.error
+		return not result.is_success() and "movement range" in result.error
 	)
 
 
@@ -507,7 +507,7 @@ func _test_execute_march() -> void:
 		# From (10,30) to (10,14) = distance 16. Exactly max.
 		var result = GameEngine.execute_order(state, {"x": 10, "y": 14}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 10
 			and result.new_state.units[0].y == 14)
 	)
@@ -521,7 +521,7 @@ func _test_execute_march() -> void:
 		# Fodder M=6, bonus 3, total 9. From (12,30) to (12,20) = 10 > 9.
 		var result = GameEngine.execute_order(state, {"x": 12, "y": 20}, [])
 
-		return not result.success and "march range" in result.error
+		return not result.is_success() and "march range" in result.error
 	)
 
 	_test("march: reject out-of-range destination", func():
@@ -532,7 +532,7 @@ func _test_execute_march() -> void:
 		# Toff M=6, bonus 2, total 8. Distance 20 > 8.
 		var result = GameEngine.execute_order(state, {"x": 10, "y": 10}, [])
 
-		return not result.success and "march range" in result.error
+		return not result.is_success() and "march range" in result.error
 	)
 
 	_test("march: diagonal move within Euclidean range succeeds (would fail Manhattan)", func():
@@ -546,7 +546,7 @@ func _test_execute_march() -> void:
 		# Manhattan would be 22 > 16 → rejected. This test proves Euclidean is active.
 		var result = GameEngine.execute_order(state, {"x": 21, "y": 26}, [])
 
-		return result.success and result.new_state.units[0].x == 21
+		return result.is_success() and result.new_state.units[0].x == 21
 	)
 
 
@@ -565,7 +565,7 @@ func _test_execute_charge() -> void:
 		# [5,5,1,1]: 2 hits, 2 unsaved → 2 wounds → target dies.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 5, 1, 1])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 14  # moves to nearest adjacent cell
 			and result.new_state.units[0].y == 10
 			and result.new_state.units[1].is_dead)
@@ -581,7 +581,7 @@ func _test_execute_charge() -> void:
 
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 5, 1, 1])
 
-		return not result.success and "charge range" in result.error
+		return not result.is_success() and "charge range" in result.error
 	)
 
 	_test("charge: close_combat equipment reduces inaccuracy by 1", func():
@@ -596,7 +596,7 @@ func _test_execute_charge() -> void:
 		# Roll 5s for attacks (hits only with CC bonus), 1s for saves.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [5, 5, 1, 1])
 
-		return result.success and result.new_state.units[1].is_dead
+		return result.is_success() and result.new_state.units[1].is_dead
 	)
 
 	_test("charge: fizzle succeeds when no enemy in charge range", func():
@@ -609,7 +609,7 @@ func _test_execute_charge() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
-		return (result.success and result.new_state.units[0].has_ordered)
+		return (result.is_success() and result.new_state.units[0].has_ordered)
 	)
 
 	_test("charge: fizzle rejected when a valid target exists", func():
@@ -620,7 +620,7 @@ func _test_execute_charge() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
-		return not result.success and "Cannot fizzle" in result.error
+		return not result.is_success() and "Cannot fizzle" in result.error
 	)
 
 
@@ -707,7 +707,7 @@ func _test_panic_test() -> void:
 		# After +1 panic token, target has 5 tokens. Retreat distance = D6 + 2×5 =
 		# 2 + 10 = 12. Target was at (15,10), charger at (10,10), retreat +X.
 		# Ideal destination: (27, 10).
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 14  # charger moved adjacent
 			and not result.new_state.units[1].is_dead  # no melee happened
 			and result.new_state.units[1].panic_tokens == 5  # +1 from failed test
@@ -727,7 +727,7 @@ func _test_panic_test() -> void:
 		var params = {"target_id": state.units[1].id, "panic_die": 3, "fearless_die": 1}
 		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[1].is_dead  # melee resolved, target killed
 			and result.new_state.units[1].panic_tokens == 2)  # no extra panic
 	)
@@ -755,7 +755,7 @@ func _test_panic_test() -> void:
 			dice.append(1)
 		var result = GameEngine.execute_order(state, params, dice)
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 14  # charger moved
 			and result.new_state.units[1].panic_tokens == 5  # +1 post-melee
 			and result.new_state.units[1].model_count < 6)  # melee happened, took casualties
@@ -962,7 +962,7 @@ func _test_melee_bouts() -> void:
 		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
 		var result = GameEngine.execute_order(state, params, dice)
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].panic_tokens == 1  # attacker +1 post-melee
 			and result.new_state.units[1].panic_tokens == 1  # defender +1 post-melee
 			and not result.new_state.units[0].is_dead
@@ -994,7 +994,7 @@ func _test_melee_bouts() -> void:
 		# Defender at (11,10), charger now at charge_dest.x. Retreat direction = -x.
 		# So final charger x < charge_dest.x.
 		var charger = result.new_state.units[0]
-		return (result.success
+		return (result.is_success()
 			and not charger.is_dead
 			and charger.panic_tokens == 1  # +1 post-melee
 			and charger.x < 11  # retreated away from defender
@@ -1143,7 +1143,7 @@ func _test_shooting_engagements() -> void:
 
 		# Defender had 0 panic tokens, got hit → +1 panic. Retreat distance = 2 + 2*1 = 4.
 		# Defender at (20,15), attacker at (10,15), retreat +X → (24,15).
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[1].panic_tokens == 1
 			and result.new_state.units[1].x == 24
 			and result.new_state.units[1].y == 15)
@@ -1161,7 +1161,7 @@ func _test_shooting_engagements() -> void:
 		var result = GameEngine.execute_order(state, params, [4, 1, 5, 1])
 
 		# Neither retreats; both still at original positions.
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 10 and result.new_state.units[0].y == 15
 			and result.new_state.units[1].x == 20 and result.new_state.units[1].y == 15
 			and result.new_state.units[0].current_wounds == 1
@@ -1184,7 +1184,7 @@ func _test_shooting_engagements() -> void:
 		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1, 5, 1])
 
 		# Attacker took 1 wound from return fire; defender dead.
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[1].is_dead
 			and result.new_state.units[0].current_wounds == 1)
 	)
@@ -1205,7 +1205,7 @@ func _test_shooting_engagements() -> void:
 		var result = GameEngine.execute_order(state, params, [5, 1, 5, 1])
 
 		# Both hit+wound → tie, no retreat. Confirms return fire measured from (14,15).
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].x == 14
 			and result.new_state.units[0].current_wounds == 1
 			and result.new_state.units[1].current_wounds == 1)
@@ -1287,7 +1287,7 @@ func _test_line_of_sight() -> void:
 
 		# Try to target u1 (farther) instead of u3 (closer) — should be rejected.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1])
-		return not result.success and "closest" in result.error
+		return not result.is_success() and "closest" in result.error
 	)
 
 	_test("closest-target: tied-closest both legal", func():
@@ -1308,7 +1308,7 @@ func _test_line_of_sight() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 		var r2 = GameEngine.execute_order(state, {"target_id": state.units[3].id}, [6, 1, 1, 1])
 
-		return r1.success and r2.success
+		return r1.is_success() and r2.is_success()
 	)
 
 	_test("closest-target: Sharpshooters bypass restriction", func():
@@ -1322,7 +1322,7 @@ func _test_line_of_sight() -> void:
 
 		# Target u1 (farther) — should succeed for Sharpshooters. Enough dice for engagement.
 		var result = GameEngine.execute_order(state, {"target_id": state.units[1].id}, [6, 1, 1, 1])
-		return result.success
+		return result.is_success()
 	)
 
 	_test("volley_fire: LoS blocked = fizzle succeeds", func():
@@ -1338,7 +1338,7 @@ func _test_line_of_sight() -> void:
 		state = GameEngine.declare_order(state, state.units[0].id, "volley_fire", 3, [3, 3]).new_state
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
-		return result.success
+		return result.is_success()
 	)
 
 	_test("charge: LoS required to target", func():
@@ -1352,7 +1352,7 @@ func _test_line_of_sight() -> void:
 
 		var params = {"target_id": state.units[1].id, "panic_die": 1, "fearless_die": 1}
 		var result = GameEngine.execute_order(state, params, [5, 5, 1, 1])
-		return not result.success and "line of sight" in result.error
+		return not result.is_success() and "line of sight" in result.error
 	)
 
 
@@ -1366,7 +1366,7 @@ func _test_advance_flow() -> void:
 
 		var result = GameEngine.execute_order(state, {"x": 10, "y": 24}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.active_seat == 2
 			and result.new_state.order_phase == "snob_select")
 	)
@@ -1378,7 +1378,7 @@ func _test_advance_flow() -> void:
 
 		var result = GameEngine.execute_order(state, {"x": 12, "y": 24}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.units[0].has_ordered  # Snob
 			and result.new_state.units[2].has_ordered)  # Follower
 	)
@@ -1408,7 +1408,7 @@ func _test_advance_flow() -> void:
 		state = GameEngine.declare_self_order(state, state.units[2].id, "march", 3, [3, 3]).new_state
 		var result = GameEngine.execute_order(state, {"x": 12, "y": 24}, [])
 
-		return (result.success
+		return (result.is_success()
 			and result.new_state.current_round == 2
 			and not result.new_state.units[0].has_ordered  # flags cleared
 			and result.new_state.order_phase == "snob_select")
@@ -1424,7 +1424,7 @@ func _test_advance_flow() -> void:
 		state = GameEngine.declare_self_order(state, state.units[2].id, "march", 3, [3, 3]).new_state
 		var result = GameEngine.execute_order(state, {"x": 12, "y": 24}, [])
 
-		return result.success and result.new_state.phase == "finished"
+		return result.is_success() and result.new_state.phase == "finished"
 	)
 
 	_test("advance: powder smoke cleared at round end", func():
@@ -1437,7 +1437,7 @@ func _test_advance_flow() -> void:
 		state = GameEngine.declare_self_order(state, state.units[2].id, "march", 3, [3, 3]).new_state
 		var result = GameEngine.execute_order(state, {"x": 12, "y": 24}, [])
 
-		return result.success and not result.new_state.units[0].has_powder_smoke
+		return result.is_success() and not result.new_state.units[0].has_powder_smoke
 	)
 
 
@@ -1579,7 +1579,7 @@ func _test_objectives() -> void:
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, follower.id, "march", 4, [3, 3]).new_state
 		var res = GameEngine.execute_order(state, {"x": 20, "y": 15}, [])
-		return not res.success and "objective" in res.error
+		return not res.is_success() and "objective" in res.error
 	)
 
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -635,28 +635,28 @@ func _test_panic_test() -> void:
 	_test("panic_test: 0 tokens auto-passes", func():
 		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
 		unit.panic_tokens = 0
-		var result = GameEngine._panic_test(unit, 6, 1)
+		var result = GameEngine.Panic.panic_test(unit, 6, 1)
 		return result["passed"] and result["auto_passed"]
 	)
 
 	_test("panic_test: natural 1 always passes regardless of tokens", func():
 		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
 		unit.panic_tokens = 6  # max tokens, but die=1 → pass
-		var result = GameEngine._panic_test(unit, 1, 1)
+		var result = GameEngine.Panic.panic_test(unit, 1, 1)
 		return result["passed"] and not result["auto_passed"]
 	)
 
 	_test("panic_test: D6 + tokens <= 6 passes", func():
 		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
 		unit.panic_tokens = 3  # die=3, total=6 ≤ 6 → pass
-		var result = GameEngine._panic_test(unit, 3, 1)
+		var result = GameEngine.Panic.panic_test(unit, 3, 1)
 		return result["passed"] and result["total"] == 6
 	)
 
 	_test("panic_test: D6 + tokens >= 7 fails", func():
 		var unit = _mock_unit("u0", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
 		unit.panic_tokens = 3  # die=4, total=7 ≥ 7 → fail
-		var result = GameEngine._panic_test(unit, 4, 1)
+		var result = GameEngine.Panic.panic_test(unit, 4, 1)
 		return not result["passed"] and result["total"] == 7
 	)
 
@@ -665,7 +665,7 @@ func _test_panic_test() -> void:
 		var rules: Array[String] = ["fearless"]
 		var unit = Types.UnitState.new("u0", 1, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
 		unit.panic_tokens = 4  # die=5, total=9 → fail, but Fearless 3+ saves
-		var result = GameEngine._panic_test(unit, 5, 3)
+		var result = GameEngine.Panic.panic_test(unit, 5, 3)
 		return result["passed"] and result["fearless_override"] and result["used_fearless"]
 	)
 
@@ -674,7 +674,7 @@ func _test_panic_test() -> void:
 		var rules: Array[String] = ["fearless"]
 		var unit = Types.UnitState.new("u0", 1, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
 		unit.panic_tokens = 4  # die=5, total=9 → fail, Fearless die=2 → still fails
-		var result = GameEngine._panic_test(unit, 5, 2)
+		var result = GameEngine.Panic.panic_test(unit, 5, 2)
 		return not result["passed"] and result["used_fearless"] and not result["fearless_override"]
 	)
 
@@ -683,7 +683,7 @@ func _test_panic_test() -> void:
 		var rules: Array[String] = ["safety_in_numbers"]
 		var unit = Types.UnitState.new("u0", 1, "Fodder", "infantry", 8, 12, stats, "black_powder", rules)
 		unit.panic_tokens = 4
-		var result = GameEngine._panic_test(unit, 5, 4)  # total=9, Fearless die=4 → override
+		var result = GameEngine.Panic.panic_test(unit, 5, 4)  # total=9, Fearless die=4 → override
 		return result["passed"] and result["fearless_override"]
 	)
 
@@ -692,7 +692,7 @@ func _test_panic_test() -> void:
 		var rules: Array[String] = ["safety_in_numbers"]
 		var unit = Types.UnitState.new("u0", 1, "Fodder", "infantry", 7, 12, stats, "black_powder", rules)
 		unit.panic_tokens = 4
-		var result = GameEngine._panic_test(unit, 5, 4)  # total=9, but not Fearless → fails
+		var result = GameEngine.Panic.panic_test(unit, 5, 4)  # total=9, but not Fearless → fails
 		return not result["passed"] and not result["used_fearless"]
 	)
 
@@ -777,7 +777,7 @@ func _test_retreat() -> void:
 		state.units[2].x = 20; state.units[2].y = 15
 		state.units[2].panic_tokens = 3
 		state.units[1].x = 15; state.units[1].y = 15  # nearest enemy
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 3)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 3)
 		return (result["retreated"]
 			and result["distance"] == 9
 			and state.units[2].x == 29
@@ -791,7 +791,7 @@ func _test_retreat() -> void:
 		state.units[2].x = 20; state.units[2].y = 20
 		state.units[2].panic_tokens = 2
 		state.units[1].x = 17; state.units[1].y = 17
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 1)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 1)
 		return (result["retreated"]
 			and state.units[2].x == 24
 			and state.units[2].y == 24)
@@ -803,7 +803,7 @@ func _test_retreat() -> void:
 		state.units[2].x = 20; state.units[2].y = 15
 		state.units[2].panic_tokens = 0
 		state.units[1].x = 15; state.units[1].y = 15
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 4)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 4)
 		return (result["retreated"]
 			and result["distance"] == 4
 			and state.units[2].x == 24)
@@ -816,7 +816,7 @@ func _test_retreat() -> void:
 		state.units[2].x = 46; state.units[2].y = 15
 		state.units[2].panic_tokens = 3
 		state.units[1].x = 44; state.units[1].y = 15
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 1)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 1)
 		return (result["retreated"]
 			and result["destroyed"]
 			and state.units[2].is_dead
@@ -832,7 +832,7 @@ func _test_retreat() -> void:
 		stump.panic_tokens = 4
 		state.units.append(stump)
 		state.units[1].x = 15; state.units[1].y = 15
-		var result = GameEngine._execute_retreat(state, "stump", 6)
+		var result = GameEngine.Panic.execute_retreat(state, "stump", 6)
 		return (result["stubborn_held"]
 			and not result["retreated"]
 			and stump.x == 20 and stump.y == 15)
@@ -846,7 +846,7 @@ func _test_retreat() -> void:
 		state.units[2].panic_tokens = 1
 		state.units[1].x = 18; state.units[1].y = 15
 		state.units[3].x = 23; state.units[3].y = 15  # blocker at ideal dest
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 1)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 1)
 		return (result["retreated"]
 			and (state.units[2].x != 23 or state.units[2].y != 15))
 	)
@@ -857,7 +857,7 @@ func _test_retreat() -> void:
 		state.units[2].x = 20; state.units[2].y = 15
 		state.units[2].panic_tokens = 0
 		state.units[1].x = 15; state.units[1].y = 15
-		var result = GameEngine._execute_retreat(state, state.units[2].id, 6)
+		var result = GameEngine.Panic.execute_retreat(state, state.units[2].id, 6)
 		return (result["retreated"]
 			and result["distance"] == 6
 			and state.units[2].x == 26)

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -1455,7 +1455,7 @@ func _test_victory_conditions() -> void:
 			if unit.owner_seat == 2:
 				unit.is_dead = true
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 1
 	)
 
@@ -1463,7 +1463,7 @@ func _test_victory_conditions() -> void:
 		var state = _mock_orders_state()
 		state.units[0].is_dead = true  # kill seat 1 Snob
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 2 and "Snobs" in victory["reason"]
 	)
 
@@ -1474,14 +1474,14 @@ func _test_victory_conditions() -> void:
 		state.units.append(_mock_unit("u0", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1))
 		state.units[0].x = 10; state.units[0].y = 10
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 0
 	)
 
 	_test("No winner when both have living units and snobs", func():
 		var state = _mock_orders_state()
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 0 and victory["reason"] == ""
 	)
 
@@ -1491,7 +1491,7 @@ func _test_victory_conditions() -> void:
 		state.max_rounds = 4
 		state.objectives = _mock_objectives([[1, 2], [1, 0], [2, 0]])
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 1 and "2 objective" in victory["reason"]
 	)
 
@@ -1506,7 +1506,7 @@ func _test_victory_conditions() -> void:
 				unit.model_count += 5
 				break
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 0 and "Draw" in victory["reason"]
 	)
 
@@ -1516,7 +1516,7 @@ func _test_victory_conditions() -> void:
 		state.max_rounds = 4
 		state.objectives = _mock_objectives([[0, 0], [0, 0]])
 
-		var victory = GameEngine.check_victory(state)
+		var victory = Objectives.check_victory(state)
 		return victory["winner"] == 0 and "Draw" in victory["reason"]
 	)
 
@@ -1533,7 +1533,7 @@ func _test_objectives() -> void:
 		var state = _mock_orders_state()
 		state.objectives = _mock_objectives_at([[20, 15]])
 		state.units[2].x = 20; state.units[2].y = 16  # seat 1 Follower
-		GameEngine._resolve_objective_captures(state)
+		GameEngine.Objectives.resolve_objective_captures(state)
 		return state.objectives[0].captured_by == 1
 	)
 
@@ -1541,7 +1541,7 @@ func _test_objectives() -> void:
 		var state = _mock_orders_state()
 		state.objectives = _mock_objectives_at([[10, 29]])
 		# Seat 1 Snob at (10, 30) is already adjacent to (10, 29).
-		GameEngine._resolve_objective_captures(state)
+		GameEngine.Objectives.resolve_objective_captures(state)
 		return state.objectives[0].captured_by == 0
 	)
 
@@ -1551,7 +1551,7 @@ func _test_objectives() -> void:
 		state.objectives[0].captured_by = 1  # Pre-existing control
 		state.units[2].x = 15; state.units[2].y = 14  # seat 1 Follower
 		state.units[3].x = 15; state.units[3].y = 16  # seat 2 Follower
-		GameEngine._resolve_objective_captures(state)
+		GameEngine.Objectives.resolve_objective_captures(state)
 		return state.objectives[0].captured_by == 0
 	)
 
@@ -1562,7 +1562,7 @@ func _test_objectives() -> void:
 		# No followers adjacent at all.
 		state.units[2].x = 0; state.units[2].y = 0
 		state.units[3].x = 0; state.units[3].y = 31
-		GameEngine._resolve_objective_captures(state)
+		GameEngine.Objectives.resolve_objective_captures(state)
 		return state.objectives[0].captured_by == 2
 	)
 
@@ -1573,7 +1573,7 @@ func _test_objectives() -> void:
 		# Seat 2 Follower adjacent, seat 1 Follower far away.
 		state.units[2].x = 0; state.units[2].y = 0
 		state.units[3].x = 20; state.units[3].y = 14
-		GameEngine._resolve_objective_captures(state)
+		GameEngine.Objectives.resolve_objective_captures(state)
 		return state.objectives[0].captured_by == 2
 	)
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -3,6 +3,11 @@ extends SceneTree
 ##
 ## Run with: godot --headless -s tests/test_game_engine.gd
 
+const Targeting = preload("res://game/targeting.gd")
+const Combat = preload("res://game/combat.gd")
+const Panic = preload("res://game/panic.gd")
+const Objectives = preload("res://game/objectives.gd")
+
 var _tests_passed: int = 0
 var _tests_failed: int = 0
 
@@ -988,7 +993,7 @@ func _test_melee_bouts() -> void:
 		var result = GameEngine.execute_order(state, params, dice)
 
 		# Charger moved adjacent to (x=10, y=10 → x=10 target at 11), charge_dest x=10 wait...
-		# _find_adjacent_cell picks nearest adjacent cell to target. Target at (11,10), charger
+		# Targeting.find_adjacent_cell picks nearest adjacent cell to target. Target at (11,10), charger
 		# approaching from (10,10) → adjacent cell (10,10) itself is distance 1 from target. Fine.
 		# After losing: charger retreats 2×(panic_tokens_after_melee=1) = 2 cells away from defender.
 		# Defender at (11,10), charger now at charge_dest.x. Retreat direction = -x.
@@ -1222,7 +1227,7 @@ func _test_line_of_sight() -> void:
 		# No blockers between them
 		state.units[2].x = 5; state.units[2].y = 5  # out of the way
 		state.units[3].x = 30; state.units[3].y = 5  # out of the way
-		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+		return GameEngine.Targeting.has_line_of_sight(state, 10, 15, 20, 15)
 	)
 
 	_test("LoS: Follower unit on the line blocks", func():
@@ -1231,7 +1236,7 @@ func _test_line_of_sight() -> void:
 		state.units[1].x = 20; state.units[1].y = 15
 		# Place a Follower directly between them
 		state.units[2].x = 15; state.units[2].y = 15
-		return not GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+		return not GameEngine.Targeting.has_line_of_sight(state, 10, 15, 20, 15)
 	)
 
 	_test("LoS: Snob on the line does NOT block", func():
@@ -1244,7 +1249,7 @@ func _test_line_of_sight() -> void:
 		state.units[3].x = 20; state.units[3].y = 15  # Follower as actual target
 		# LoS from u0 to u3 should pass — u1 (Snob) doesn't block.
 		state.units[2].x = 5; state.units[2].y = 5  # out of the way
-		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+		return GameEngine.Targeting.has_line_of_sight(state, 10, 15, 20, 15)
 	)
 
 	_test("LoS: dead unit on the line does NOT block", func():
@@ -1254,7 +1259,7 @@ func _test_line_of_sight() -> void:
 		state.units[2].x = 15; state.units[2].y = 15  # Follower in the way
 		state.units[2].is_dead = true  # but dead
 		state.units[3].x = 30; state.units[3].y = 5
-		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+		return GameEngine.Targeting.has_line_of_sight(state, 10, 15, 20, 15)
 	)
 
 	_test("LoS: endpoints are excluded from blocker check", func():
@@ -1264,7 +1269,7 @@ func _test_line_of_sight() -> void:
 		state.units[3].x = 20; state.units[3].y = 15
 		state.units[0].x = 5; state.units[0].y = 5
 		state.units[1].x = 30; state.units[1].y = 5
-		return GameEngine._has_line_of_sight(state, 10, 15, 20, 15)
+		return GameEngine.Targeting.has_line_of_sight(state, 10, 15, 20, 15)
 	)
 
 	_test("LoS: diagonal line blocked by unit on the path", func():
@@ -1274,7 +1279,7 @@ func _test_line_of_sight() -> void:
 		# Place blocker at (13,13) — on the diagonal line
 		state.units[2].x = 13; state.units[2].y = 13
 		state.units[3].x = 30; state.units[3].y = 5
-		return not GameEngine._has_line_of_sight(state, 10, 10, 16, 16)
+		return not GameEngine.Targeting.has_line_of_sight(state, 10, 10, 16, 16)
 	)
 
 	_test("closest-target: reject non-closest enemy", func():

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -867,13 +867,13 @@ func _test_retreat() -> void:
 func _test_melee_bouts() -> void:
 	print("\n[Test Suite: Melee Bouts]")
 
-	# --- Direct _resolve_melee unit tests ---
+	# --- Direct Combat.resolve_melee unit tests ---
 
 	_test("melee: attacker kills defender in bout 1, no counter-attack", func():
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		# Attacker 2 attacks × 2 dice = 4 dice. [5,5,1,1] → 2 hits, 2 unsaved → defender dies.
-		var combat = GameEngine._resolve_melee(atk, def, [5, 5, 1, 1])
+		var combat = GameEngine.Combat.resolve_melee(atk, def, [5, 5, 1, 1])
 		return (combat["error"] == ""
 			and combat["bouts"].size() == 1
 			and combat["winner_id"] == "atk"
@@ -888,7 +888,7 @@ func _test_melee_bouts() -> void:
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		# Attacker [1,1,1,1] → 0 hits. Defender [5,5,1,1] → 2 unsaved → attacker dies.
-		var combat = GameEngine._resolve_melee(atk, def, [1, 1, 1, 1, 5, 5, 1, 1])
+		var combat = GameEngine.Combat.resolve_melee(atk, def, [1, 1, 1, 1, 5, 5, 1, 1])
 		return (combat["error"] == ""
 			and combat["bouts"].size() == 1
 			and combat["winner_id"] == "def"
@@ -902,7 +902,7 @@ func _test_melee_bouts() -> void:
 		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		# Bout 1: both whiff (0-0 tie). Bout 2: attacker kills.
 		var dice = [1, 1, 1, 1,   1, 1, 1, 1,   5, 5, 1, 1]
-		var combat = GameEngine._resolve_melee(atk, def, dice)
+		var combat = GameEngine.Combat.resolve_melee(atk, def, dice)
 		return (combat["error"] == ""
 			and combat["bouts"].size() == 2
 			and combat["winner_id"] == "atk"
@@ -918,9 +918,9 @@ func _test_melee_bouts() -> void:
 		var dice: Array = []
 		for i in range(24):
 			dice.append(1)
-		var combat = GameEngine._resolve_melee(atk, def, dice)
+		var combat = GameEngine.Combat.resolve_melee(atk, def, dice)
 		return (combat["error"] == ""
-			and combat["bouts"].size() == GameEngine.MELEE_MAX_BOUTS
+			and combat["bouts"].size() == Combat.MELEE_MAX_BOUTS
 			and combat["draw"]
 			and combat["winner_id"] == ""
 			and combat["loser_id"] == ""
@@ -932,7 +932,7 @@ func _test_melee_bouts() -> void:
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		def.is_dead = true
-		var combat = GameEngine._resolve_melee(atk, def, [])
+		var combat = GameEngine.Combat.resolve_melee(atk, def, [])
 		return combat["error"] != ""
 	)
 
@@ -940,7 +940,7 @@ func _test_melee_bouts() -> void:
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		var def = _mock_unit("def", 2, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
 		# Attacker needs 4 dice, give it 2.
-		var combat = GameEngine._resolve_melee(atk, def, [5, 5])
+		var combat = GameEngine.Combat.resolve_melee(atk, def, [5, 5])
 		return combat["error"] != "" and "Not enough dice" in combat["error"]
 	)
 
@@ -1012,7 +1012,7 @@ func _test_melee_bouts() -> void:
 func _test_shooting_engagements() -> void:
 	print("\n[Test Suite: Shooting Engagements]")
 
-	# --- Direct _resolve_shooting_engagement tests ---
+	# --- Direct Combat.resolve_shooting_engagement tests ---
 
 	_test("engagement: return fire fires when target in range with weapon", func():
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
@@ -1020,7 +1020,7 @@ func _test_shooting_engagements() -> void:
 		atk.x = 10; atk.y = 10
 		dfn.x = 15; dfn.y = 10  # within 18
 		# Attacker [5,1] hits + wounds (I5+, V5). Defender [5,1] same.
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1, 5, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [5, 1, 5, 1], 0)
 		return (combat["error"] == ""
 			and combat["return_fire_fired"]
 			and combat["att_hits"] == 1 and combat["att_wounds"] == 1
@@ -1035,7 +1035,7 @@ func _test_shooting_engagements() -> void:
 		atk.x = 10; atk.y = 10
 		dfn.x = 15; dfn.y = 10
 		dfn.has_powder_smoke = true
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [5, 1], 0)
 		return (combat["error"] == ""
 			and not combat["return_fire_fired"]
 			and combat["att_wounds"] == 1
@@ -1051,7 +1051,7 @@ func _test_shooting_engagements() -> void:
 		atk.x = 10; atk.y = 10
 		dfn.x = 20; dfn.y = 10
 		atk.base_stats.weapon_range = 18
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [5, 1], 0)
 		return (combat["error"] == ""
 			and not combat["return_fire_fired"]
 			and combat["winner_id"] == "atk")
@@ -1062,7 +1062,7 @@ func _test_shooting_engagements() -> void:
 		var dfn = _mock_unit("dfn", 2, "Brutes", "infantry", 6, 2, 5, 2, 5, 0, 1)
 		atk.x = 10; atk.y = 10
 		dfn.x = 12; dfn.y = 10
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [5, 1], 0)
 		return combat["error"] == "" and not combat["return_fire_fired"]
 	)
 
@@ -1078,7 +1078,7 @@ func _test_shooting_engagements() -> void:
 		# should not reduce the pool.
 		var dice = [5, 5, 5, 5, 1, 1, 1, 1,   # attacker 4 hits, 4 wounds
 					5, 5, 5, 1, 1, 1]          # defender 3 hits (I5+), 3 wounds
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, dice, 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, dice, 0)
 		return (combat["error"] == ""
 			and combat["return_fire_fired"]
 			and combat["att_hits"] == 4 and combat["att_wounds"] == 4
@@ -1095,7 +1095,7 @@ func _test_shooting_engagements() -> void:
 		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
 		atk.x = 10; atk.y = 10
 		dfn.x = 15; dfn.y = 10
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [5, 1, 1, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [5, 1, 1, 1], 0)
 		return (combat["error"] == ""
 			and combat["winner_id"] == "atk"
 			and combat["loser_id"] == "dfn"
@@ -1107,7 +1107,7 @@ func _test_shooting_engagements() -> void:
 		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
 		atk.x = 10; atk.y = 10
 		dfn.x = 15; dfn.y = 10
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [1, 1, 5, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [1, 1, 5, 1], 0)
 		return (combat["error"] == ""
 			and combat["winner_id"] == "dfn"
 			and combat["loser_id"] == "atk"
@@ -1119,7 +1119,7 @@ func _test_shooting_engagements() -> void:
 		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
 		atk.x = 10; atk.y = 10
 		dfn.x = 15; dfn.y = 10
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [1, 1, 1, 1], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [1, 1, 1, 1], 0)
 		return (combat["error"] == ""
 			and combat["tie"]
 			and combat["winner_id"] == "" and combat["loser_id"] == "")
@@ -1129,7 +1129,7 @@ func _test_shooting_engagements() -> void:
 		var atk = _mock_unit("atk", 1, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
 		var dfn = _mock_unit("dfn", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
 		dfn.is_dead = true
-		var combat = GameEngine._resolve_shooting_engagement(atk, dfn, [], 0)
+		var combat = GameEngine.Combat.resolve_shooting_engagement(atk, dfn, [], 0)
 		return combat["error"] != ""
 	)
 

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -89,6 +89,18 @@ func _test_types() -> void:
 		return snob.is_snob() and snob.get_command_range() == 6
 	)
 
+	_test("UnitState/UnitDef do not alias special_rules across instances", func():
+		var rules: Array[String] = ["fearless"]
+		var stats = Types.Stats.new(6, 2, 5, 2, 5, 6)
+		var u1 = Types.UnitState.new("a", 1, "Toff", "snob", 1, 1, stats, "", rules)
+		var u2 = Types.UnitState.new("b", 1, "Toff", "snob", 1, 1, stats, "", rules)
+		u1.special_rules.append("stubborn")
+		var def1 = Types.UnitDef.new("Toff", "snob", 1, stats, rules)
+		var def2 = Types.UnitDef.new("Toff", "snob", 1, stats, rules)
+		def1.special_rules.append("dervish")
+		return u2.special_rules.size() == 1 and def2.special_rules.size() == 1 and rules.size() == 1
+	)
+
 	_test("GameState with initiative and rounds", func():
 		var gs = Types.GameState.new("ABCD", "placement", 1, 4, 1, 2)
 		var dict = gs.to_dict()

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -3,6 +3,8 @@ extends SceneTree
 ##
 ## Run with: godot --headless -s tests/test_runner.gd
 
+const Targeting = preload("res://game/targeting.gd")
+
 var _tests_passed: int = 0
 var _tests_failed: int = 0
 
@@ -15,6 +17,7 @@ func _init() -> void:
 	_test_types()
 	_test_ruleset_loader()
 	_test_roster_validation()
+	_test_targeting()
 
 	print("")
 	print("============================================================")
@@ -241,6 +244,79 @@ func _test_roster_validation() -> void:
 		])
 
 		return ruleset.validate_roster(roster) != ""
+	)
+
+
+## Test Targeting line-of-sight semantics. Builds tiny game states with
+## hand-placed units and asserts what blocks LoS.
+func _test_targeting() -> void:
+	print("\n[Test Suite: Targeting]")
+
+	var _make_state := func(units: Array[Types.UnitState]) -> Types.GameState:
+		return Types.GameState.new("ABCD", "battle", 1, 4, 1, 1, units, [], 0)
+
+	# A Follower (non-Snob) standing on a cell does block LoS through that cell.
+	# Stats with movement=6 placed at (5, 5).
+	var stats = Types.Stats.new(6, 2, 5, 2, 5, 6)
+
+	_test("LoS: open line, no blockers", func():
+		var units: Array[Types.UnitState] = []
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 5, 0)
+	)
+
+	_test("LoS: Follower on midline blocks", func():
+		var blocker = Types.UnitState.new("b", 1, "Fodder", "follower", 1, 1, stats, "", [], 0, false, 0, 3, 0)
+		var units: Array[Types.UnitState] = [blocker]
+		var state = _make_state.call(units)
+		return not Targeting.has_line_of_sight(state, 0, 0, 6, 0)
+	)
+
+	_test("LoS: Snob on midline does NOT block (v17 p.5)", func():
+		var snob = Types.UnitState.new("s", 1, "Toff", "snob", 1, 1, stats, "", [], 0, false, 0, 3, 0)
+		var units: Array[Types.UnitState] = [snob]
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 6, 0)
+	)
+
+	_test("LoS: dead Follower does NOT block", func():
+		var corpse = Types.UnitState.new("c", 1, "Fodder", "follower", 0, 1, stats, "", [], 0, false, 0, 3, 0, false, true, "")
+		var units: Array[Types.UnitState] = [corpse]
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 6, 0)
+	)
+
+	_test("LoS: blocker AT endpoint does not block its own visibility", func():
+		# A unit standing at the to-cell is the target itself; it must not
+		# block LoS to itself.
+		var target = Types.UnitState.new("t", 2, "Fodder", "follower", 1, 1, stats, "", [], 0, false, 0, 6, 0)
+		var units: Array[Types.UnitState] = [target]
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 6, 0)
+	)
+
+	_test("LoS: blocker AT origin does not block (shooter at from)", func():
+		var shooter = Types.UnitState.new("sh", 1, "Fodder", "follower", 1, 1, stats, "", [], 0, false, 0, 0, 0)
+		var units: Array[Types.UnitState] = [shooter]
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 6, 0)
+	)
+
+	_test("LoS: diagonal supercover catches off-axis blocker", func():
+		# Shooting from (0,0) to (4,4). On a pure diagonal walk the line passes
+		# through cells where the supercover Bresenham checks (cx+sx, cy) and
+		# (cx, cy+sy). Place a Follower at (1,0) to ensure the axis-adjacent
+		# check fires.
+		var blocker = Types.UnitState.new("b", 1, "Fodder", "follower", 1, 1, stats, "", [], 0, false, 0, 1, 0)
+		var units: Array[Types.UnitState] = [blocker]
+		var state = _make_state.call(units)
+		return not Targeting.has_line_of_sight(state, 0, 0, 4, 4)
+	)
+
+	_test("LoS: clear diagonal passes when no blocker", func():
+		var units: Array[Types.UnitState] = []
+		var state = _make_state.call(units)
+		return Targeting.has_line_of_sight(state, 0, 0, 4, 4)
 	)
 
 

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -96,6 +96,16 @@ func _test_types() -> void:
 		return restored.initiative_seat == 2 and restored.max_rounds == 4
 	)
 
+	_test("GameState clone deep-copies action_log entries", func():
+		var log: Array[Dictionary] = [{"type": "shoot", "shooter": "u1", "dice": [3, 4, 5]}]
+		var units: Array[Types.UnitState] = []
+		var src = Types.GameState.new("ABCD", "placement", 1, 4, 1, 1, units, log, 0)
+		var clone = Types.GameState.from_dict(src.to_dict())
+		clone.action_log[0]["shooter"] = "MUTATED"
+		(clone.action_log[0]["dice"] as Array).append(6)
+		return src.action_log[0]["shooter"] == "u1" and (src.action_log[0]["dice"] as Array).size() == 3
+	)
+
 
 ## Test Ruleset loading and validation
 func _test_ruleset_loader() -> void:

--- a/memory/checkpoint-2026-04-25-line-of-sight.md
+++ b/memory/checkpoint-2026-04-25-line-of-sight.md
@@ -1,0 +1,120 @@
+# Checkpoint — Line of Sight + Closest-Target Enforcement
+
+**Date:** 2026-04-25
+**PR:** #76
+**Branch:** feature/line-of-sight (merged + deleted)
+
+Backfilled checkpoint — pre-merge-housekeeping was skipped on this PR, so
+this is written retroactively from PR #76 + commit `a15729b`. Pre-scoping
+lives in `memory/checkpoint-2026-04-22-session-wrap.md`; the implementation
+followed that scope without deviation.
+
+## What shipped
+
+Six new static helpers in `godot/server/game_engine.gd`, all pure (no
+state mutation, no RNG):
+
+- `_has_line_of_sight(state, from_x, from_y, to_x, to_y) -> bool`
+  (game_engine.gd:1587) — supercover line walk between integer cells. Any
+  alive **non-Snob** unit strictly between the endpoints blocks. Snobs
+  never block (v17 p.5). Endpoints excluded; dead units don't block.
+- `_find_shooting_targets(state, shooter) -> Array` (game_engine.gd:1650)
+  — alive + enemy + in weapon range + LoS, from shooter's current cell.
+- `_find_shooting_targets_from(state, shooter, from_x, from_y) -> Array`
+  (game_engine.gd:1667) — same, but LoS measured from an arbitrary cell.
+  Used by Move & Shoot to validate post-move LoS.
+- `_is_valid_shooting_target(state, shooter, target) -> String`
+  (game_engine.gd:1688) — empty string on legal, error string on illegal.
+  Closes on: exists, alive, enemy, in range, LoS, and (unless
+  `sharpshooters`) is among the tied-closest valid enemies.
+- `_is_valid_shooting_target_from(...)` (game_engine.gd:1721) — same with
+  LoS-from-position semantics for M&S.
+
+Wired into:
+- `_execute_volley_fire` (game_engine.gd:501) — LoS + closest-target gate.
+- `_execute_move_and_shoot` (game_engine.gd:628) — LoS from post-move cell.
+- `_execute_charge` (game_engine.gd:762) — LoS required, **no**
+  closest-target (chargers can pick any reachable enemy per #56 scope).
+- Fizzle gates (game_engine.gd:1799, 1811) updated to use the same
+  helpers, so panic-fail / no-target-available paths agree with the
+  validation gates.
+
+11 new tests in `godot/tests/test_game_engine.gd`: LoS clear, LoS blocked
+by Follower, Snob doesn't block, dead unit doesn't block, endpoints don't
+block, diagonal LoS, closest-target rejection, tied-closest both legal,
+Sharpshooters bypass closest-target, fizzle with blocked LoS, charge with
+blocked LoS. **114 engine + 19 type = 133 tests passing.**
+
+## Design decisions
+
+- **Supercover discretization, not Bresenham.** Every cell touched by the
+  line is checked. Slightly more conservative than Bresenham (favors the
+  defender on diagonals) and avoids the "thin line slips through a corner"
+  surprise.
+- **Endpoints excluded from blocker check.** Shooter and target cells
+  never count as blockers; otherwise every unit blocks itself.
+- **Tied-closest is permissive.** If two enemies are tied for nearest, the
+  shooter may pick either. Cleaner UX than coin-flipping; matches v17 p.13
+  reading.
+- **Snobs never block.** v17 p.5 explicit rule. The supercover walk skips
+  Snob-typed units when checking blockers.
+- **Closest-target does NOT apply to charges.** Per #56 scope: a charging
+  unit may target any reachable enemy with LoS, even if a closer enemy
+  exists. This is consistent with v17's separation of shooting targeting
+  rules from charge target selection.
+- **`from_x/from_y` parameter pattern over post-move state mutation.** M&S
+  needs LoS from the post-move cell *before* committing the move. Passing
+  the cell explicitly to a `_from` variant keeps the helpers pure rather
+  than threading a hypothetical-state object.
+- **Server stays authoritative; client hints unchanged.** `grid_draw.gd`
+  still draws green target rings around all in-range enemies, including
+  ones behind blockers. Clicks on those will fail server-side. Deferred
+  visual fix called out in PR body and below.
+
+## Deferred
+
+- **#58 Terrain LoS blocking** — terrain doesn't exist yet. When it lands,
+  `_has_line_of_sight` gains a terrain check inside the supercover loop.
+- **Client-side LoS hints** (no issue filed; trivial when the time comes)
+  — `grid_draw.gd` should suppress target rings on enemies without LoS so
+  players don't click illegal targets. Server-authoritative behavior is
+  correct today; this is purely UX.
+
+## Board state after
+
+PR #76 closed #56. **Phase 4 combat engine continues to converge on
+rules-completeness.** Open mechanics + audit issues:
+
+- **#54** — Stand and Shoot ← unblocked by this PR, natural next pickup
+- **#46** — 1" rule (can't end move within 1" of another unit)
+- **#47** — Charge: fail-still-move-full + 1" exception
+- **#48** — Snob moves with its commanded unit during order
+- **#49** — Reroll infrastructure (once-only enforcement)
+- **#50** — Vanguard: pre-game free move phase
+- **#51** — Dash: Whelps free move after order
+- **#57** — Toff Off! Snob duel mechanic
+- **#58** — Terrain system (Cover/Defensible/Dangerous/Impassable) —
+  large; blocks #62
+- **#59** — Scenario system (objectives, blunders, table layout)
+- **#62** — Dangerous terrain test on retreat through Followers (blocked
+  by #58)
+- **#38** — remaining v17 audit items
+- **#42** — cult rules audit (pre-deploy)
+
+Out-of-mechanics: **#64–#70, #72, #74** all available. **#65 (refactor:
+split oversized files)** is starting to itch — `game_engine.gd` is now
+1800+ lines with this PR's helpers added. Worth thinking about before
+#54/#58 inflate it further.
+
+No new issues filed this session.
+
+## Next pickup
+
+**#54 — Stand and Shoot.** Unblocked by this PR (depends on LoS), small
+scope (defender fires at charger before melee resolves), and the LoS code
+is freshly in head. Reuses `_is_valid_shooting_target` directly.
+
+Alternatively, if file size is bothering you, **#65** (refactor split) is
+a good rainy-day pickup before more mechanics pile in — `game_engine.gd`
+is the obvious split candidate, with targeting/LoS, combat resolution,
+and order execution as the natural seams.


### PR DESCRIPTION
## Summary

Splits the 1932-line `game_engine.gd` monolith into five focused, pure-RefCounted modules under `game/`. Closes #65.

- **Five new modules** in `game/`: `board.gd` (geometry + move validation), `targeting.gd` (LoS + valid-target enumeration), `combat.gd` (shooting + melee resolution), `panic.gd` (panic test + retreat), `objectives.gd` (capture + victory)
- **`game_engine.gd` reduced from 1932 → 1061 lines** (-871). Residual is order-flow orchestration (place_unit, declare_order, execute_order, the four `_execute_*` order handlers, and a few state-query helpers) — the rules themselves all moved out.
- **Three dormant contract bugs fixed** as warm-up commits before any extraction touched code paths.
- **Client/server validation drift eliminated** for shooting: `battle.gd` and `grid_draw.gd` now consume `Targeting` so green target rings respect LoS — previously they only checked Euclidean range and would ring units the shooter couldn't actually see.
- **Tests stayed green at every commit**: 114 engine + 29 type = 143 total (+10 new: 8 LoS unit tests for the targeting module, +1 action_log clone regression, +1 special_rules alias regression).

## Commit shape

15 commits, ordered to keep the diff easy to follow:

1. Three hardening commits — `_find_unit_in` dedupe, `action_log` deep-copy, `special_rules.duplicate()`
2. Five module extractions — each adds a new `game/X.gd` and leaves thin wrappers in `game_engine.gd` (per the locked \"no rename + relocate in one commit\" rule)
3. One client wire-up — `battle.gd` + `grid_draw.gd` consume `Targeting`
4. `EngineResult.success` removal — replaced with `is_success()` derived from `error.is_empty()`
5. Five wrapper-sweep commits — one per module, deleting the wrappers and pointing every caller at `Module.X` directly

Per-commit test status was verified manually with the headless Godot test runner; the per-commit message records the count.

## Bugs fixed

- `_find_unit_in` was byte-identical to `_find_unit` with contradictory docstrings (read-only vs. mutable). Contract trap.
- `GameState.from_dict` used `Array.assign` on `action_log`, which is shallow on inner Dicts. Cloned state's log entries aliased the source. Dormant — no current code path mutates a logged entry post-clone — but landmines any future feature that wants to enrich log entries in a what-if simulation.
- `UnitDef._init` and `UnitState._init` assigned `p_special_rules` by reference. Two instances built from one source array (or one shared template) shared the array. Mutating one mutated the other.
- Green shooting target rings ignored LoS. A unit hidden behind a Follower screen was still ringed; the \"no enemies in range\" fizzle banner only fired when literal Euclidean range was empty even if every nominal target was occluded.

All four were sitting dormant or only producing wrong UI hints — none caused engine-test failures, but they were each reachable by a future contributor.

## What's deliberately NOT in this PR

- Engine functions like `_clone_state`, `_find_unit`, `_has_unordered_snobs`, `_has_valid_volley_target`, `get_followers_in_command_range` stay in `game_engine.gd`. They're orchestration helpers, not pure rules.
- `game_engine.gd` itself stays under `server/`. Moving it under `game/` is a separate decision (touches autoload wiring) and was explicitly out of scope per #65.
- `_find_adjacent_cell` 4-cardinal limitation is filed separately as #77 and lives in `targeting.gd` post-extraction so the fix only touches one file.
- Caching `find_shooting_targets` results is speculative until perf bites.

## Test plan

- [x] All 114 engine tests pass at every commit
- [x] All 29 type tests pass at every commit (was 19 pre-PR; +10 new)
- [x] Manual smoke test: full local stack (server + 2 clients), placement → orders → shooting engagement → melee → retreat. Logs reviewed, only pre-existing benign warnings.
- [ ] Reviewer plays a turn and confirms green shooting rings respect LoS (try shooting through a Follower screen — units behind the screen should NOT get a ring; Snobs in the line should not block; charge rings should still ignore LoS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)