### PR TITLE
fix(targeting): accept diagonal charge contact (#77)

### DIFF
--- a/godot/game/targeting.gd
+++ b/godot/game/targeting.gd
@@ -145,14 +145,17 @@ static func is_valid_shooting_target_from(state: Types.GameState, shooter: Types
 
 ## Find the best adjacent cell to a target for a charging unit.
 ##
-## Currently checks only 4-cardinal neighbors (N/S/E/W). Diagonal-adjacent
-## charge contact (within √2) is rejected — tracked separately as a bug
-## (#77) and lives here so the fix only touches one file.
+## Iterates all 8 neighbors (4 cardinal + 4 diagonal). v17 base contact is
+## "touching base", which on the integer grid means any of the 8 ring cells
+## around the target. Tie-break: cell closest to the charger.
 static func find_adjacent_cell(state: Types.GameState, charger: Types.UnitState, target: Types.UnitState) -> Vector2i:
 	var best = Vector2i(-1, -1)
-	var best_dist = 9999
+	var best_dist = 9999.0
 
-	for offset in [Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1)]:
+	for offset in [
+		Vector2i(1, 0), Vector2i(-1, 0), Vector2i(0, 1), Vector2i(0, -1),
+		Vector2i(1, 1), Vector2i(1, -1), Vector2i(-1, 1), Vector2i(-1, -1),
+	]:
 		var cx = target.x + offset.x
 		var cy = target.y + offset.y
 		if not Board.is_in_bounds(cx, cy):

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -33,6 +33,7 @@ func _init() -> void:
 	_test_advance_flow()
 	_test_victory_conditions()
 	_test_objectives()
+	_test_targeting()
 
 	print("")
 	print("============================================================")
@@ -1585,6 +1586,72 @@ func _test_objectives() -> void:
 		state = GameEngine.declare_order(state, follower.id, "march", 4, [3, 3]).new_state
 		var res = GameEngine.execute_order(state, {"x": 20, "y": 15}, [])
 		return not res.is_success() and "objective" in res.error
+	)
+
+
+func _test_targeting() -> void:
+	print("")
+	print("[Test Suite: Targeting]")
+
+	_test("find_adjacent_cell: cardinals blocked → diagonal contact accepted", func():
+		# Charger at (8,8), target at (10,10). All four cardinal cells around
+		# the target are occupied by friendlies; diagonals are open. Pre-fix
+		# this returned (-1,-1) and rejected the charge as "no open cell".
+		var state = _mock_orders_state()
+		var charger = state.units[0]
+		var target = state.units[1]
+		charger.x = 8; charger.y = 8
+		target.x = 10; target.y = 10
+		# Block all 4 cardinals around the target with the two Followers
+		# plus two extra blockers we add to state.units.
+		state.units[2].x = 9; state.units[2].y = 10   # seat 1 Follower
+		state.units[3].x = 11; state.units[3].y = 10  # seat 2 Follower
+		var blocker_a = _mock_unit("blk_a", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
+		blocker_a.x = 10; blocker_a.y = 9
+		var blocker_b = _mock_unit("blk_b", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
+		blocker_b.x = 10; blocker_b.y = 11
+		state.units.append(blocker_a)
+		state.units.append(blocker_b)
+
+		var cell = Targeting.find_adjacent_cell(state, charger, target)
+		# Closest diagonal to charger at (8,8) is (9,9) — distance √2 ≈ 1.41.
+		return cell.x == 9 and cell.y == 9
+	)
+
+	_test("find_adjacent_cell: cardinal preferred when both available", func():
+		# Charger directly west of target, no blockers. Cardinal (9,10) at
+		# distance 1.0 from charger should beat diagonals (9,9)/(9,11) at √2.
+		var state = _mock_orders_state()
+		var charger = state.units[0]
+		var target = state.units[1]
+		charger.x = 8; charger.y = 10
+		target.x = 10; target.y = 10
+		# Move other units far away so they don't accidentally block anything.
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 0; state.units[3].y = 31
+
+		var cell = Targeting.find_adjacent_cell(state, charger, target)
+		return cell.x == 9 and cell.y == 10
+	)
+
+	_test("find_adjacent_cell: all 8 neighbors blocked → returns sentinel", func():
+		var state = _mock_orders_state()
+		var charger = state.units[0]
+		var target = state.units[1]
+		charger.x = 5; charger.y = 5
+		target.x = 10; target.y = 10
+		# Move existing extras out of the way, then block all 8 ring cells.
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 0; state.units[3].y = 31
+		var ring = [[9,9],[9,10],[9,11],[10,9],[10,11],[11,9],[11,10],[11,11]]
+		for i in range(ring.size()):
+			var p = ring[i]
+			var blk = _mock_unit("blk_%d" % i, 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
+			blk.x = p[0]; blk.y = p[1]
+			state.units.append(blk)
+
+		var cell = Targeting.find_adjacent_cell(state, charger, target)
+		return cell.x == -1 and cell.y == -1
 	)
 
 


### PR DESCRIPTION
## Summary
- `Targeting.find_adjacent_cell` only checked the 4 cardinal neighbors of the target, so a charge with cardinals blocked but diagonals open was rejected as "no open cell adjacent to target."
- v17 base contact is "touching base" — on the integer grid that's any of the 8 ring cells. Iterate all 8; tie-break by Euclidean distance from charger, so cardinals still win when both are available.
- Adds direct unit tests for `Targeting.find_adjacent_cell` covering corner-trap diagonal acceptance, cardinal preference, and fully-blocked sentinel.

Closes #77.

## Test plan
- [x] `godot --headless -s tests/test_game_engine.gd` — 117 / 117 passing (3 new targeting tests added)
- [x] `godot --headless -s tests/test_runner.gd` — 29 / 29 passing
- [x] Existing charge integration tests still pass (cell selection unchanged when cardinals are open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)