### PR TITLE
feat(engine): Stand and Shoot reaction before melee (#54)

### DIFF
--- a/godot/game/combat.gd
+++ b/godot/game/combat.gd
@@ -76,6 +76,75 @@ static func resolve_shooting_side(attacker: Types.UnitState, target: Types.UnitS
 			"dice_used": needed_dice, "error": ""}
 
 
+## Is the target eligible to Stand and Shoot at the charger? v17 core p.16:
+## the target MUST Stand and Shoot if it has a ranged weapon and no powder
+## smoke. A unit equipped for close combat may never Stand and Shoot.
+## Range and line of sight are NOT required ("the unit waits until just
+## before impact before firing").
+static func can_stand_and_shoot(target: Types.UnitState) -> bool:
+	if target.is_dead:
+		return false
+	if target.base_stats.weapon_range <= 0:
+		return false
+	if target.has_powder_smoke:
+		return false
+	if target.equipment == "close_combat":
+		return false
+	return true
+
+
+## Resolve a Stand and Shoot reaction (v17 core p.16). One-sided: target
+## fires at charger; the charger CANNOT return fire (rules: "this is a
+## shooting attack, not a shooting engagement"). Wounds, panic token, and
+## powder smoke are applied per the standard shooting attack steps (p.14).
+##
+## Caller must check can_stand_and_shoot() first. Caller must NOT call this
+## if the target failed its panic test — the target retreated instead and
+## never reaches this step (v17 p.16 step 3).
+##
+## Returns {
+##   hits, saves, wounds,        # all from target shooting at charger
+##   charger_dead: bool,         # true if S&S wiped the charger
+##   smoke_applied: bool,        # target gained a powder smoke token
+##   dice_used: int,
+##   error: String,
+## }
+static func resolve_stand_and_shoot(target: Types.UnitState, charger: Types.UnitState, dice_results: Array, offset: int) -> Dictionary:
+	var result = {
+		"hits": 0, "saves": 0, "wounds": 0,
+		"charger_dead": false,
+		"smoke_applied": false,
+		"dice_used": 0,
+		"error": "",
+	}
+
+	var shot = resolve_shooting_side(target, charger, dice_results, offset, 0)
+	if shot["error"] != "":
+		result["error"] = shot["error"]
+		return result
+
+	result["hits"] = shot["hits"]
+	result["saves"] = shot["saves"]
+	result["wounds"] = shot["unsaved_wounds"]
+	result["dice_used"] = shot["dice_used"]
+
+	apply_wounds(charger, result["wounds"])
+	result["charger_dead"] = charger.is_dead
+
+	# Standard shooting attack rule (v17 p.14 step 5): any hit, saved or
+	# not, gives the target unit a panic token. Charger only — S&S is one-
+	# sided so the firing target gets no panic from this exchange.
+	if result["hits"] > 0 and not charger.is_dead:
+		charger.panic_tokens = mini(charger.panic_tokens + 1, 6)
+
+	# Black powder weapons gain a powder smoke token after firing (v17 p.14).
+	if target.equipment == "black_powder":
+		target.has_powder_smoke = true
+		result["smoke_applied"] = true
+
+	return result
+
+
 ## Is the target eligible to return fire at the shooter? v17 core p.13:
 ## target must have a ranged weapon, no powder smoke, and the shooter must
 ## be within the target's weapon range. Casualties from the primary strike

--- a/godot/server/game_engine.gd
+++ b/godot/server/game_engine.gd
@@ -812,12 +812,57 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		]
 		return result
 
+	# v17 core p.16 step 3: target Stands and Shoots if able. Only fires
+	# after the panic test passed (failed panic = retreat path above, no
+	# S&S). The charger CANNOT return fire — this is a one-sided shooting
+	# attack, not a shooting engagement. Range/LoS not required.
+	var stand_and_shoot: Dictionary = {}
+	var ss_dice_used: int = 0
+	if Combat.can_stand_and_shoot(new_target):
+		stand_and_shoot = Combat.resolve_stand_and_shoot(new_target, new_unit, dice_results, 0)
+		if stand_and_shoot["error"] != "":
+			result.error = stand_and_shoot["error"]
+			return result
+		ss_dice_used = stand_and_shoot["dice_used"]
+
+		if new_unit.is_dead:
+			# Charger wiped out by Stand and Shoot — no melee, no movement.
+			# Charger sits dead at its starting square; defender holds.
+			_advance_after_order(new_state)
+
+			var ss_panic_log = panic if not panic["auto_passed"] else {}
+			new_state.action_log.append({
+				"round": state.current_round,
+				"seat": state.active_seat,
+				"action": "charge",
+				"unit_id": unit.id,
+				"unit_type": unit.unit_type,
+				"target_id": target_id,
+				"target_type": target.unit_type,
+				"charge_range": charge_range,
+				"blundered": state.current_order_blundered,
+				"panic_test": ss_panic_log,
+				"target_fled": false,
+				"stand_and_shoot": stand_and_shoot,
+				"charger_destroyed_by_ss": true,
+				"unsaved_wounds": 0,
+				"counter_unsaved_wounds": 0,
+			})
+
+			result.new_state = new_state
+			result.dice_rolled = [panic_die, fearless_die] + dice_results.slice(0, ss_dice_used)
+			result.description = "Charge! %s → %s — Stand and Shoot wiped out the charger [CHARGER DESTROYED]" % [
+				unit.unit_type, target.unit_type
+			]
+			return result
+
 	# Move to adjacent cell
 	new_unit.x = charge_dest.x
 	new_unit.y = charge_dest.y
 
-	# Resolve melee as bouts (v17 core p.18)
-	var combat = Combat.resolve_melee(new_unit, new_target, dice_results)
+	# Resolve melee as bouts (v17 core p.18). Melee dice come AFTER any
+	# Stand and Shoot dice consumed above.
+	var combat = Combat.resolve_melee(new_unit, new_target, dice_results.slice(ss_dice_used))
 	if combat["error"] != "":
 		result.error = combat["error"]
 		return result
@@ -863,6 +908,8 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		"blundered": state.current_order_blundered,
 		"panic_test": panic_log,
 		"target_fled": false,
+		"stand_and_shoot": stand_and_shoot,
+		"charger_destroyed_by_ss": false,
 		"bouts": combat["bouts"],
 		"melee_draw": combat["draw"],
 		"melee_winner_id": combat["winner_id"],
@@ -880,6 +927,10 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		panic_text = " (target Fearless — held!)"
 	elif not panic["auto_passed"]:
 		panic_text = " (target passed panic test)"
+
+	var ss_text = ""
+	if not stand_and_shoot.is_empty() and stand_and_shoot.get("wounds", 0) > 0:
+		ss_text = " — S&S %d wounds" % stand_and_shoot["wounds"]
 
 	var outcome_text: String
 	if combat["draw"]:
@@ -899,8 +950,8 @@ static func _execute_charge(state: Types.GameState, unit: Types.UnitState, param
 		elif retreat.get("destroyed", false):
 			outcome_text += " — charger fled off board [DESTROYED]"
 
-	result.description = "Charge! %s → %s%s — %s (atk %d / def %d wounds)" % [
-		unit.unit_type, target.unit_type, panic_text, outcome_text,
+	result.description = "Charge! %s → %s%s%s — %s (atk %d / def %d wounds)" % [
+		unit.unit_type, target.unit_type, panic_text, ss_text, outcome_text,
 		atk_wounds_total, def_wounds_total,
 	]
 

--- a/godot/server/network_server.gd
+++ b/godot/server/network_server.gd
@@ -379,15 +379,20 @@ func _roll_execute_dice(state: Types.GameState, params: Dictionary) -> Array:
 				def_dice = s_target.model_count * 2
 			num_dice = att_dice + def_dice
 		"charge":
-			# Worst case: attacker + defender each strike every bout. Target
-			# may be unknown at roll time (fizzle path) — fall back to a
-			# symmetric pool sized to the attacker.
+			# Stand and Shoot dice (target shoots charger before melee, v17
+			# p.16) come first, then melee dice. Worst-case melee: attacker
+			# + defender each strike every bout. Target may be unknown at
+			# roll time (fizzle path) — fall back to symmetric pools, with
+			# the charger's own model_count standing in for S&S budget so
+			# we never under-roll.
 			var atk_per_bout = unit.model_count * unit.base_stats.attacks * 2
 			var def_per_bout = atk_per_bout
+			var ss_dice = unit.model_count * 2
 			var target = _find_unit(state, params.get("target_id", ""))
 			if target != null:
 				def_per_bout = target.model_count * target.base_stats.attacks * 2
-			num_dice = (atk_per_bout + def_per_bout) * Combat.MELEE_MAX_BOUTS
+				ss_dice = target.model_count * 2 if Combat.can_stand_and_shoot(target) else 0
+			num_dice = ss_dice + (atk_per_bout + def_per_bout) * Combat.MELEE_MAX_BOUTS
 		"march":
 			num_dice = 0
 

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -562,6 +562,7 @@ func _test_execute_charge() -> void:
 		var state = _mock_orders_state()
 		state.units[0].x = 10; state.units[0].y = 10
 		state.units[1].x = 15; state.units[1].y = 10
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot (tested elsewhere)
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		# Self-order, dice [3, 3]: bonus = 6. Toff M=6 → range 12. Distance to target = 5.
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
@@ -595,6 +596,7 @@ func _test_execute_charge() -> void:
 		state.units[1].x = 11; state.units[1].y = 10
 		state.units[0].equipment = "close_combat"
 		state.units[0].base_stats.inaccuracy = 6  # Without CC would need 6+; with CC 5+.
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
@@ -626,6 +628,136 @@ func _test_execute_charge() -> void:
 
 		var result = GameEngine.execute_order(state, {"fizzle": true}, [])
 		return not result.is_success() and "Cannot fizzle" in result.error
+	)
+
+	# --- Stand and Shoot reaction (v17 core p.16 step 3) ---
+
+	_test("S&S: eligibility — ranged + no smoke + not close-combat", func():
+		var t = _mock_unit("t", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		var ok_eligible = Combat.can_stand_and_shoot(t)
+
+		var smoked = _mock_unit("s", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		smoked.has_powder_smoke = true
+		var ok_smoked = not Combat.can_stand_and_shoot(smoked)
+
+		var no_range = _mock_unit("n", 2, "Toff", "snob", 6, 2, 5, 2, 5, 0, 1)
+		var ok_no_range = not Combat.can_stand_and_shoot(no_range)
+
+		var cc = _mock_unit("c", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		cc.equipment = "close_combat"
+		var ok_cc = not Combat.can_stand_and_shoot(cc)
+
+		var dead = _mock_unit("d", 2, "Toff", "snob", 6, 2, 5, 2, 5, 18, 1)
+		dead.is_dead = true
+		var ok_dead = not Combat.can_stand_and_shoot(dead)
+
+		return ok_eligible and ok_smoked and ok_no_range and ok_cc and ok_dead
+	)
+
+	_test("S&S: target fires before melee, charger takes wounds", func():
+		# Charger Toff (1 model, V=5, W=2) charges target Toff Snob (1 model,
+		# wr=18, I=5). S&S: 1×2=2 dice. [5,1] → 1 hit, 1 unsaved → charger
+		# takes 1 wound (current_wounds=1 of 2, still alive). Then melee:
+		# 4 dice for charger strike + 4 for counter = 8 dice. Charger
+		# [1,1,1,1] whiffs, target counters [5,5,1,1] → 2 unsaved → charger
+		# dies in counter-strike (current_wounds 1 + 2 = 3 ≥ W=2 → dead).
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var dice = [5, 1] + [1, 1, 1, 1] + [5, 5, 1, 1]
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		var ss = result.new_state.action_log[-1].get("stand_and_shoot", {})
+		return (result.is_success()
+			and ss.get("hits", 0) == 1
+			and ss.get("wounds", 0) == 1
+			and result.new_state.units[1].has_powder_smoke  # target now smoked
+			and result.new_state.units[0].is_dead  # charger died in melee counter
+			and result.new_state.units[0].panic_tokens >= 1)  # +1 from S&S hit
+	)
+
+	_test("S&S: powder smoke on target blocks Stand and Shoot", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10
+		state.units[1].has_powder_smoke = true
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		# No S&S dice consumed → melee dice start at offset 0.
+		var dice = [5, 5, 1, 1, 1, 1, 1, 1]
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		var ss = result.new_state.action_log[-1].get("stand_and_shoot", {})
+		return (result.is_success()
+			and ss.is_empty()  # never resolved
+			and result.new_state.units[1].is_dead)  # melee killed target
+	)
+
+	_test("S&S: close-combat-equipped target cannot Stand and Shoot", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 11; state.units[1].y = 10
+		state.units[1].equipment = "close_combat"
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var dice = [5, 5, 1, 1, 1, 1, 1, 1]
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		var ss = result.new_state.action_log[-1].get("stand_and_shoot", {})
+		return result.is_success() and ss.is_empty() and result.new_state.units[1].is_dead
+	)
+
+	_test("S&S: wipes out charger → charge ends, no melee, defender holds", func():
+		# Beef up target dice + give charger 1 wound so 1 wound from S&S
+		# kills it. S&S 1×2=2 dice [5,1] → 1 hit, 1 unsaved → charger dies.
+		# Melee dice provided but should NOT be consumed.
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[0].base_stats.wounds = 1
+		state.units[1].x = 15; state.units[1].y = 10
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var dice = [5, 1] + [5, 5, 5, 5, 5, 5, 5, 5]
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1}
+		var result = GameEngine.execute_order(state, params, dice)
+
+		var log = result.new_state.action_log[-1]
+		return (result.is_success()
+			and result.new_state.units[0].is_dead  # charger destroyed by S&S
+			and not result.new_state.units[1].is_dead  # defender unscathed
+			and log.get("charger_destroyed_by_ss", false)
+			and log.get("stand_and_shoot", {}).get("charger_dead", false)
+			and not ("bouts" in log)  # melee never happened
+			and result.new_state.units[1].has_powder_smoke)
+	)
+
+	_test("S&S: failed panic test → target retreats, no Stand and Shoot", func():
+		# Per v17 p.16: S&S happens AFTER panic-pass (step 3 follows step 2
+		# success). Failed panic = retreat path, no S&S.
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 15; state.units[1].y = 10
+		state.units[1].panic_tokens = 6  # die=6 + 6 = 12 → fail
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
+
+		var params = {"target_id": state.units[1].id, "panic_die": 6, "fearless_die": 1, "retreat_die": 3}
+		var result = GameEngine.execute_order(state, params, [])
+
+		var log = result.new_state.action_log[-1]
+		return (result.is_success()
+			and log.get("target_fled", false)
+			and not ("stand_and_shoot" in log)  # never set on retreat path
+			and not result.new_state.units[1].has_powder_smoke)  # never fired
 	)
 
 
@@ -726,6 +858,7 @@ func _test_panic_test() -> void:
 		state.units[0].x = 10; state.units[0].y = 10
 		state.units[1].x = 15; state.units[1].y = 10
 		state.units[1].panic_tokens = 2  # die=3 → total=5 ≤ 6 → pass
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
@@ -746,6 +879,7 @@ func _test_panic_test() -> void:
 		state.units[1] = Types.UnitState.new("u1", 2, "Brutes", "infantry", 6, 6, stats, "black_powder", rules)
 		state.units[1].x = 15; state.units[1].y = 10
 		state.units[1].panic_tokens = 4  # die=5 → total=9, Fearless die=3 → override
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [3, 3]).new_state
 
@@ -955,6 +1089,7 @@ func _test_melee_bouts() -> void:
 		# Give defender multiple models so melee doesn't end via death.
 		# Replace u1 with 6-model Brutes-like unit (use Toff stats for simplicity).
 		state.units[1].model_count = 6
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [1, 1]).new_state
 
@@ -982,6 +1117,7 @@ func _test_melee_bouts() -> void:
 		state.units[1].panic_tokens = 0
 		# Boost charger wounds so it survives the bout and can retreat.
 		state.units[0].base_stats.wounds = 5
+		state.units[1].has_powder_smoke = true  # skip Stand and Shoot
 		state = GameEngine.select_snob(state, state.units[0].id).new_state
 		state = GameEngine.declare_order(state, state.units[0].id, "charge", 3, [1, 1]).new_state
 


### PR DESCRIPTION
## Summary
- Implements v17 core p.16 step 3: charge target that passes its panic test MUST Stand and Shoot if it has a ranged weapon and no powder smoke.
- Range and LoS are **not** required (\"the unit waits until just before impact before firing\"). Close-combat-equipped units never Stand and Shoot. Charger cannot return fire — it's a shooting attack, not an engagement.
- Powder smoke applied after. Any hit gives the charger a panic token (standard shooting attack rules, p.14). If S&S wipes out the charger, charge ends with no melee.

### Implementation
- New \`Combat.can_stand_and_shoot(target)\` predicate and \`Combat.resolve_stand_and_shoot()\` resolver — one-sided, mirrors the \`resolve_shooting_side\` shape.
- Wired into \`_execute_charge\` between panic-pass and melee. Failed panic test skips S&S (the target retreated).
- Charge dice budget bumped in \`_roll_execute_dice\` so the server pre-rolls the S&S dice ahead of the melee pool.
- Action log gains \`stand_and_shoot\` and \`charger_destroyed_by_ss\` fields for the post-engagement summary.

### Test changes
- Existing charge integration tests now set \`target.has_powder_smoke = true\` to skip S&S where the test focuses on melee/panic mechanics. No dice arrays were touched.
- Six new tests added in \`_test_execute_charge\`:
  - eligibility predicate (ranged + no smoke + not close-combat + alive)
  - S&S fires before melee, charger takes wounds
  - powder smoke on target blocks S&S
  - close-combat-equipped target blocks S&S
  - S&S wipes out charger → charge ends, no melee, defender unscathed
  - failed panic test → target retreats, no S&S

Closes #54.

## Test plan
- [x] \`godot --headless -s tests/test_game_engine.gd\` — 120 / 120 passing (6 new S&S tests, 6 existing charge tests adjusted)
- [x] \`godot --headless -s tests/test_runner.gd\` — 29 / 29 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)