### PR TITLE
feat(engine): 1" rule on non-charge moves (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ godot/
 ├── game/               # Pure logic — NO node/scene dependencies
 │   ├── types.gd        # Stats (M/A/I/W/V), UnitDef, Roster, UnitState, GameState
 │   ├── ruleset.gd      # Loads + validates v17 JSON rulesets, validates rosters
+│   ├── board.gd        # Grid geometry, distance, move validation (1" rule)
+│   ├── targeting.gd    # LoS, valid-target enumeration, charge contact cells
+│   ├── combat.gd       # Shooting engagements, Stand & Shoot, melee bouts
+│   ├── panic.gd        # Panic test, retreat, Fearless, Stubborn Fanatics
+│   ├── objectives.gd   # Objective capture + victory conditions
 │   └── rulesets/       # One JSON file per ruleset (v17.json)
 ├── server/             # Server-only (server_main, game_engine, networking)
 ├── client/             # Client-only (main, scenes/menu, lobby, battle)

--- a/docs/wiki/Manual-Testing-Guide.md
+++ b/docs/wiki/Manual-Testing-Guide.md
@@ -71,8 +71,8 @@ Each round, players alternate picking Snobs to "Make Ready." The sidebar is phas
 **order_execute** — run the order
 - Sidebar shows the declared order, blundered state, and movement range with dice bonus applied.
 - **Volley Fire:** click an enemy unit to fire (`-1 Inaccuracy` unless blundered). Shooting resolves as a simultaneous engagement (v17 p.13): the target returns fire if it has a ranged weapon, no powder smoke, and the shooter is in range. Casualties from the primary shot do not suppress return fire. Winner (more unsaved wounds) forces the loser to retreat `D6 + 2" × panic tokens`; ties produce no retreat.
-- **March:** click a destination cell within `M + move_bonus`.
-- **Charge:** click an enemy within `M + move_bonus`; attacker auto-pathfinds to an adjacent cell and resolves melee as bouts (v17 p.18) — attacker strikes, defender removes casualties, defender counter-strikes, winner = more unsaved wounds per bout. Tied bouts repeat up to 3×; cap-hit ties draw with no retreat. Post-melee both survivors gain +1 panic; the loser retreats (which can include the charger).
+- **March:** click a destination cell within `M + move_bonus`. The destination must be ≥1" from any enemy and (if the marcher is a Follower) ≥1" from any friendly Follower (v17 p.9, "the 1" rule"). Snobs are exempt for friendlies but not for enemies. Diagonal-adjacent cells (√2 ≈ 1.41") are legal; cardinal-adjacent (1.0") is rejected.
+- **Charge:** click an enemy within `M + move_bonus`; attacker auto-pathfinds to an adjacent cell and resolves the charge sequence — target panic test (v17 p.16 step 2), Stand and Shoot if the target passed and is eligible (ranged weapon, no powder smoke, not close-combat-equipped — v17 p.16 step 3), then melee as bouts (v17 p.18). Attacker strikes, defender removes casualties, defender counter-strikes, winner = more unsaved wounds per bout. Tied bouts repeat up to 3×; cap-hit ties draw with no retreat. Post-melee both survivors gain +1 panic; the loser retreats (which can include the charger). Charge end-cell must be >1" from any non-target unit (v17 p.17, stricter than the standard rule — even friendly Snobs near the contact cell block it).
 - **Move & Shoot:** click a destination (max `M`, or `1D6` if blundered), then click an enemy to fire from the new position *or* press **Confirm move (no shot)** to skip the shot. The engagement rule is the same as Volley Fire — return-fire range is measured from the shooter's post-move position.
 
 On success the turn either passes to the opposing seat (if they still have unordered Snobs), or — once both sides' Snobs are done — transitions to `follower_self_order`.
@@ -130,6 +130,9 @@ The fastest way to force each path without an hour-long game:
 | Melee bouts | Target passes panic → bout loop runs: attacker strikes, defender removes dead, defender counter-strikes (if alive), attacker removes dead. Winner = more unsaved wounds that bout; tied bouts repeat up to 3 before draw. Both survivors +1 panic after the melee; loser retreats (charger can end up retreating instead of holding the cell). | Only one side rolls, no counter-attack, melee always ends after one pass, charger always holds the cell regardless of outcome |
 | Shooting engagement | Volley Fire / Move & Shoot resolves both sides simultaneously when target is eligible to return fire (has ranged weapon, no powder smoke, shooter in range — measured from post-move position for Move & Shoot). Casualties don't suppress return fire. Winner's loser retreats `D6 + 2"×tokens`; tie = no retreat. Each side gains +1 panic token per side that took hits. | Only shooter rolls, return fire ignored after heavy casualties, smoked unit still returns fire, tied engagement still retreats someone |
 | Move & Shoot two-click | Destination staged → Confirm button appears | Confirm never appears, or first click executes immediately |
+| 1" rule on march/move&shoot | Cardinal-adjacent (distance 1.0) cells next to enemies are rejected with `Cannot end move within 1" of enemy unit`. Snobs can end within 1" of friendly Followers; Followers cannot. Diagonal-adjacent (1.41") is legal. | Server accepts cardinal-adjacent landing, or rejects diagonal-adjacent |
+| 1" rule on charge | Charge end-cell must be >1" from any non-target unit. If the only legal cells next to the target are within 1" of a third unit, charge fails with `No open cell adjacent to target`. | Charge succeeds with end-cell within 1" of a non-target friendly or enemy |
+| Stand and Shoot | If the target passes its panic test and has a ranged weapon, no powder smoke, and isn't close-combat-equipped, it fires at the charger before melee. Charger takes wounds (and gains a panic token if any hit landed) before bouts begin. If the charger is wiped out by S&S, the charge ends with no melee and no movement; defender holds. Range and LoS are not required for S&S. | S&S never fires on a viable charge target, or fires after melee, or charger reaches melee at full strength after a hit-landing S&S |
 | Round advance | `has_ordered` clears on all units, powder smoke gone | Units stay marked ordered across rounds |
 
 ---
@@ -158,6 +161,7 @@ These should all surface server-side errors in `test-logs/server.log` and in the
 - Declare order on Follower outside command range
 - Charge enemy out of `M + move_bonus` range
 - March to a cell farther than allowed
+- March or Move & Shoot to a cell within 1" of an enemy (server returns `Cannot end move within 1"...`)
 - Act on opponent's turn (server returns `Not your turn`)
 
 ---

--- a/godot/game/board.gd
+++ b/godot/game/board.gd
@@ -31,10 +31,22 @@ static func is_in_bounds(x: int, y: int) -> bool:
 	return x >= 0 and x < BOARD_WIDTH and y >= 0 and y < BOARD_HEIGHT
 
 
-## Validate that `unit` may end its move on (x, y). Returns "" on success,
-## else a human-readable error string. Checks bounds, occupancy by other
-## live units, and the v17 rule that a unit may move across an objective
-## but not finish a move on top of one (v17 core p.22).
+## Validate that `unit` may end a non-charge move (march, move-and-shoot)
+## on (x, y). Returns "" on success, else a human-readable error string.
+## Checks:
+##   - in bounds (board edges)
+##   - cell not occupied by another live unit
+##   - cell not on an objective marker (v17 p.22)
+##   - 1" rule (v17 p.9):
+##       * a Follower may not end within 1" of another friendly Follower
+##       * any unit may not end within 1" of an enemy unit
+##       * Snobs are exempt as either mover or near-unit for friendly checks
+##         ("Snobs may be moved and end their moves within 1" of any
+##         Friendly unit"); enemy proximity always applies regardless
+##
+## Charge moves are handled in Targeting.find_adjacent_cell (v17 p.17 is
+## stricter — only the charge target gets the proximity exemption).
+## Retreat is handled in Panic._is_valid_retreat_dest (any-other-unit rule).
 static func validate_move(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> String:
 	if not is_in_bounds(x, y):
 		return "Coordinates out of bounds"
@@ -44,4 +56,22 @@ static func validate_move(state: Types.GameState, unit: Types.UnitState, x: int,
 	for obj in state.objectives:
 		if obj.x == x and obj.y == y:
 			return "Cannot end move on an objective marker"
+
+	# 1" rule (v17 p.9). Snobs exempt as either mover or as a friendly
+	# near-unit. Enemy proximity always counts.
+	var mover_is_snob: bool = unit.is_snob()
+	for u in state.units:
+		if u.is_dead or u.id == unit.id:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		if grid_distance(x, y, u.x, u.y) > 1.0:
+			continue
+		if u.owner_seat != unit.owner_seat:
+			return "Cannot end move within 1\" of enemy unit (%s)" % u.unit_type
+		# Friendly within 1": only blocks if both mover and near-unit are
+		# Followers (Snobs exempt either way).
+		if not mover_is_snob and not u.is_snob():
+			return "Cannot end move within 1\" of friendly Follower (%s)" % u.unit_type
+
 	return ""

--- a/godot/game/panic.gd
+++ b/godot/game/panic.gd
@@ -207,7 +207,11 @@ static func _find_retreat_cell(state: Types.GameState, unit: Types.UnitState, ta
 
 
 ## Is this cell a valid retreat destination? Bounds, not occupied by another
-## live unit, not on an objective marker (v17 p.22).
+## live unit, not on an objective marker (v17 p.22), and ≥1" away from any
+## other unit (v17 p.9 retreat clause: "Retreating models in a unit are
+## able to move within 1" and through any unit, so long as they end their
+## move at least 1" away from any other unit"). No Snob exemption applies
+## to retreat — the rule says "any other unit", friendly or enemy.
 static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState, x: int, y: int) -> bool:
 	if not Board.is_in_bounds(x, y):
 		return false
@@ -216,6 +220,14 @@ static func _is_valid_retreat_dest(state: Types.GameState, unit: Types.UnitState
 			return false
 	for obj in state.objectives:
 		if obj.x == x and obj.y == y:
+			return false
+	# 1" rule for retreat (v17 p.9): end ≥1" from any other unit.
+	for u in state.units:
+		if u.is_dead or u.id == unit.id:
+			continue
+		if u.x < 0 or u.y < 0:
+			continue
+		if Board.grid_distance(x, y, u.x, u.y) <= 1.0:
 			return false
 	return true
 

--- a/godot/game/targeting.gd
+++ b/godot/game/targeting.gd
@@ -148,6 +148,12 @@ static func is_valid_shooting_target_from(state: Types.GameState, shooter: Types
 ## Iterates all 8 neighbors (4 cardinal + 4 diagonal). v17 base contact is
 ## "touching base", which on the integer grid means any of the 8 ring cells
 ## around the target. Tie-break: cell closest to the charger.
+##
+## Also enforces the v17 p.17 charge-end-position rule: the cell must be
+## >1" from every unit except the target itself ("a charging unit may
+## never finish its move within 1" of another unit except the target of
+## its charge"). This is stricter than the standard p.9 1" rule — even
+## friendly Snobs near the destination block the cell.
 static func find_adjacent_cell(state: Types.GameState, charger: Types.UnitState, target: Types.UnitState) -> Vector2i:
 	var best = Vector2i(-1, -1)
 	var best_dist = 9999.0
@@ -175,6 +181,19 @@ static func find_adjacent_cell(state: Types.GameState, charger: Types.UnitState,
 				on_objective = true
 				break
 		if on_objective:
+			continue
+		# 1" rule for charges (v17 p.17): destination must be >1" from any
+		# unit except the target. No Snob exemption — strictest mode.
+		var one_inch_blocked = false
+		for u in state.units:
+			if u.is_dead or u.id == charger.id or u.id == target.id:
+				continue
+			if u.x < 0 or u.y < 0:
+				continue
+			if Board.grid_distance(cx, cy, u.x, u.y) <= 1.0:
+				one_inch_blocked = true
+				break
+		if one_inch_blocked:
 			continue
 		var dist = Board.grid_distance(charger.x, charger.y, cx, cy)
 		if dist < best_dist:

--- a/godot/tests/test_game_engine.gd
+++ b/godot/tests/test_game_engine.gd
@@ -3,6 +3,7 @@ extends SceneTree
 ##
 ## Run with: godot --headless -s tests/test_game_engine.gd
 
+const Board = preload("res://game/board.gd")
 const Targeting = preload("res://game/targeting.gd")
 const Combat = preload("res://game/combat.gd")
 const Panic = preload("res://game/panic.gd")
@@ -34,6 +35,7 @@ func _init() -> void:
 	_test_victory_conditions()
 	_test_objectives()
 	_test_targeting()
+	_test_one_inch_rule()
 
 	print("")
 	print("============================================================")
@@ -1729,19 +1731,37 @@ func _test_targeting() -> void:
 	print("")
 	print("[Test Suite: Targeting]")
 
-	_test("find_adjacent_cell: cardinals blocked → diagonal contact accepted", func():
-		# Charger at (8,8), target at (10,10). All four cardinal cells around
-		# the target are occupied by friendlies; diagonals are open. Pre-fix
-		# this returned (-1,-1) and rejected the charge as "no open cell".
+	_test("find_adjacent_cell: shorter diagonal beats longer cardinal", func():
+		# Charger at (8,8), target at (10,10), no blockers. Diagonal (9,9)
+		# is √2 ≈ 1.41 from charger; closest cardinal cells (9,10) and
+		# (10,9) are 2.24 away. Pre-#77 the function only checked cardinals
+		# and returned the longer route. With the 8-neighbor ring the
+		# diagonal wins.
 		var state = _mock_orders_state()
 		var charger = state.units[0]
 		var target = state.units[1]
 		charger.x = 8; charger.y = 8
 		target.x = 10; target.y = 10
-		# Block all 4 cardinals around the target with the two Followers
-		# plus two extra blockers we add to state.units.
+		# Move other units out of 1"-rule range of any candidate cell.
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 0; state.units[3].y = 31
+
+		var cell = Targeting.find_adjacent_cell(state, charger, target)
+		return cell.x == 9 and cell.y == 9
+	)
+
+	_test("find_adjacent_cell: corner trap → 1\" rule rejects all diagonals", func():
+		# Cardinals around target blocked, only diagonals open. Each diagonal
+		# is exactly 1.0 from one of the cardinal blockers, so the charge
+		# end-position 1" rule (v17 p.17) rejects every diagonal — find
+		# returns the sentinel and the charge will fail at the call site.
+		var state = _mock_orders_state()
+		var charger = state.units[0]
+		var target = state.units[1]
+		charger.x = 8; charger.y = 8
+		target.x = 10; target.y = 10
 		state.units[2].x = 9; state.units[2].y = 10   # seat 1 Follower
-		state.units[3].x = 11; state.units[3].y = 10  # seat 2 Follower
+		state.units[3].x = 11; state.units[3].y = 10  # seat 2 Follower (enemy)
 		var blocker_a = _mock_unit("blk_a", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
 		blocker_a.x = 10; blocker_a.y = 9
 		var blocker_b = _mock_unit("blk_b", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
@@ -1750,8 +1770,7 @@ func _test_targeting() -> void:
 		state.units.append(blocker_b)
 
 		var cell = Targeting.find_adjacent_cell(state, charger, target)
-		# Closest diagonal to charger at (8,8) is (9,9) — distance √2 ≈ 1.41.
-		return cell.x == 9 and cell.y == 9
+		return cell.x == -1 and cell.y == -1
 	)
 
 	_test("find_adjacent_cell: cardinal preferred when both available", func():
@@ -1788,6 +1807,135 @@ func _test_targeting() -> void:
 
 		var cell = Targeting.find_adjacent_cell(state, charger, target)
 		return cell.x == -1 and cell.y == -1
+	)
+
+
+func _test_one_inch_rule() -> void:
+	print("")
+	print("[Test Suite: 1\" Rule]")
+
+	# --- Board.validate_move (standard p.9 mode) ---
+
+	_test("1\": Follower cannot end march within 1\" of friendly Follower", func():
+		var state = _mock_orders_state()
+		var follower = state.units[2]  # seat 1 Fodder at (12, 30)
+		var friendly_follower = _mock_unit("ff", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		friendly_follower.x = 15; friendly_follower.y = 15
+		state.units.append(friendly_follower)
+
+		# (15, 14) is cardinal-adjacent to (15, 15) — distance 1.0, illegal.
+		return Board.validate_move(state, follower, 15, 14).contains("friendly Follower")
+	)
+
+	_test("1\": Snob CAN end move within 1\" of friendly Follower", func():
+		var state = _mock_orders_state()
+		var snob = state.units[0]  # seat 1 Toff (snob)
+		var friendly_follower = _mock_unit("ff", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 12)
+		friendly_follower.x = 15; friendly_follower.y = 15
+		state.units.append(friendly_follower)
+
+		return Board.validate_move(state, snob, 15, 14) == ""
+	)
+
+	_test("1\": Follower CAN end move within 1\" of friendly Snob", func():
+		var state = _mock_orders_state()
+		var follower = state.units[2]
+		var friendly_snob = _mock_unit("fs", 1, "Toff", "snob", 6, 2, 5, 2, 5, 6, 1)
+		friendly_snob.x = 15; friendly_snob.y = 15
+		state.units.append(friendly_snob)
+
+		return Board.validate_move(state, follower, 15, 14) == ""
+	)
+
+	_test("1\": no unit may end within 1\" of an enemy", func():
+		var state = _mock_orders_state()
+		var snob = state.units[0]
+		var enemy = state.units[1]  # seat 2 Snob
+		enemy.x = 15; enemy.y = 15
+
+		# Snob mover, enemy near-unit — Snob exemption does NOT apply to enemies.
+		return Board.validate_move(state, snob, 15, 14).contains("enemy")
+	)
+
+	_test("1\": diagonal-adjacent (1.41) is legal", func():
+		var state = _mock_orders_state()
+		var follower = state.units[2]
+		var enemy = state.units[1]
+		enemy.x = 15; enemy.y = 15
+		# Move other state units out of any 1" range
+		state.units[0].x = 0; state.units[0].y = 0
+		state.units[3].x = 47; state.units[3].y = 31
+
+		# (14, 14) is diagonal to (15, 15) — distance √2 ≈ 1.41, legal.
+		return Board.validate_move(state, follower, 14, 14) == ""
+	)
+
+	# --- Integration via execute_order march ---
+
+	_test("1\": march into 1\" of enemy is rejected at order execution", func():
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 15
+		state.units[1].x = 15; state.units[1].y = 15
+		state = GameEngine.select_snob(state, state.units[0].id).new_state
+		state = GameEngine.declare_order(state, state.units[0].id, "march", 3, [3, 3]).new_state
+
+		# (15, 14) is cardinal-adjacent to enemy at (15, 15).
+		var result = GameEngine.execute_order(state, {"x": 15, "y": 14}, [])
+		return not result.is_success() and "1\"" in result.error
+	)
+
+	# --- Targeting.find_adjacent_cell (charge p.17 strict mode) ---
+
+	_test("1\" charge: non-target friendly within 1\" blocks the cell", func():
+		# Charger at (10, 10), target at (12, 10). Cardinal cells around
+		# target: (11, 10) is dist 1 from charger, dist 1 from a friendly
+		# blocker we put at (11, 9). All 4 cardinals + diagonals checked,
+		# the legal cells should exclude any cell within 1" of the friendly.
+		var state = _mock_orders_state()
+		state.units[0].x = 10; state.units[0].y = 10
+		state.units[1].x = 12; state.units[1].y = 10
+		# Move u2/u3 out of the way
+		state.units[2].x = 0; state.units[2].y = 0
+		state.units[3].x = 47; state.units[3].y = 31
+		var friendly_blocker = _mock_unit("fb", 1, "Fodder", "infantry", 6, 1, 6, 1, 6, 0, 1)
+		friendly_blocker.x = 11; friendly_blocker.y = 9
+		state.units.append(friendly_blocker)
+
+		# Cells around target (12,10): (11,10) is dist 1 from blocker — blocked.
+		# (13,10) is dist √(4+1)=2.24 — OK. (12,9) is dist √(1+0)=1 — blocked.
+		# (12,11) is dist √(1+4)=2.24 — OK. Picking the closest to charger
+		# at (10,10): (11,10) blocked, so try diagonals (11,9) is occupied,
+		# (11,11) is dist √(0+4)=2.0 from blocker, dist √2 from charger — OK.
+		var cell = Targeting.find_adjacent_cell(state, state.units[0], state.units[1])
+		# Whatever cell is chosen, it must be > 1.0 from the friendly blocker.
+		var dist_to_blocker = Board.grid_distance(cell.x, cell.y, 11, 9)
+		return cell.x != -1 and dist_to_blocker > 1.0
+	)
+
+	# --- Panic._is_valid_retreat_dest (retreat p.9 mode) ---
+
+	_test("1\" retreat: end within 1\" of friendly Snob is rejected", func():
+		# Retreat is stricter than the standard rule — even friendly Snobs
+		# count for the 1" check ("any other unit").
+		var state = _mock_orders_state()
+		var retreater = state.units[2]  # Fodder seat 1 at (12, 30)
+		retreater.x = 20; retreater.y = 20
+		retreater.panic_tokens = 1
+		state.units[1].x = 25; state.units[1].y = 20  # nearest enemy seat 2 Snob
+		# Place a friendly Snob 1" away from the would-be retreat cell.
+		state.units[0].x = 14; state.units[0].y = 20
+
+		# Retreat dist: 2" × 1 token + 3 (D6=3) = 5". Direction away from
+		# enemy (25, 20) → toward -x. Ideal cell: (15, 20) — exactly 1.0
+		# from the friendly Snob at (14, 20). The retreat dest helper
+		# should reject (15, 20) and spiral outward.
+		var result = Panic.execute_retreat(state, retreater.id, 3)
+		var to_x = result.get("to_x", -1)
+		var to_y = result.get("to_y", -1)
+		# Wherever the retreater ended up, it must be > 1.0 from the
+		# friendly Snob at (14, 20).
+		var d_to_snob = Board.grid_distance(to_x, to_y, 14, 20)
+		return result["retreated"] and d_to_snob > 1.0
 	)
 
 

--- a/memory/checkpoint-2026-04-29-one-inch-rule.md
+++ b/memory/checkpoint-2026-04-29-one-inch-rule.md
@@ -1,0 +1,190 @@
+# Checkpoint — 1" Rule
+
+**Date:** 2026-04-29
+**PR:** #81 (closes #46)
+**Branch:** `feat/46-one-inch-rule`
+
+Same-day continuation of the stand-and-shoot session. With #54 + #77 in,
+#46 was the natural next mechanic — foundational for #47 (charge fail
+movement) and #50/#51 (vanguard, dash). This checkpoint is written
+pre-merge, on the feature branch.
+
+## What shipped
+
+End-position 1" rule (v17 p.9 + p.17), enforced inline at three call
+sites with three distinct sub-rules:
+
+- **`Board.validate_move`** (`godot/game/board.gd:38`) — march and
+  move-and-shoot. Standard p.9 rules: a Follower may not end within 1"
+  of a friendly Follower; any unit (Follower or Snob) may not end
+  within 1" of an enemy. Snobs are exempt as either mover or near-unit
+  for the friendly check ("Snobs may be moved and end their moves
+  within 1" of any Friendly unit"); enemy proximity always counts.
+
+- **`Targeting.find_adjacent_cell`** (`godot/game/targeting.gd:151`) —
+  charge end position. Stricter p.17 rule: destination must be >1"
+  from any unit except the charge target. No Snob exemption — even
+  friendly Snobs near a candidate cell block it.
+
+- **`Panic._is_valid_retreat_dest`** (`godot/game/panic.gd:212`) —
+  retreat end. p.9 retreat clause: destination must be >1" from any
+  other unit. No exemptions; "any other unit" means any.
+
+Geometry, on the integer grid with Euclidean distance (per #44):
+
+- Cardinal-adjacent cells are at distance 1.0 — within 1", illegal.
+- Diagonal-adjacent cells are at √2 ≈ 1.41 — legal.
+
+Test changes:
+
+- The #77 corner-trap test asserted the diagonal `(9,9)` was selected
+  when all 4 cardinals were blocked. Under strict charge geometry
+  (p.17), every diagonal in that scenario is exactly 1.0 from a
+  cardinal blocker, so the rules-correct outcome is "no legal cell".
+  Test now asserts the sentinel `(-1, -1)`.
+- Replaced with a "shorter-diagonal" test that exercises the actual
+  #77 win case: charger at (8,8), target at (10,10), no blockers —
+  diagonal contact at √2 beats the longer cardinal route at 2.24.
+- New `_test_one_inch_rule` suite with 8 tests:
+  - Follower → friendly Follower: forbidden
+  - Snob mover → friendly Follower: allowed (mover exemption)
+  - Follower → friendly Snob: allowed (near-unit exemption)
+  - Any unit → enemy: forbidden (Snob mover doesn't help vs enemies)
+  - Diagonal-adjacent (1.41) is legal
+  - March integration via `execute_order`: rejected with `"1\""` in
+    error
+  - Charge non-target friendly within 1" blocks the cell
+  - Retreat dest within 1" of friendly Snob is rejected (no exemption
+    for retreat — spirals outward to a legal cell)
+
+Tests on branch: **132 engine + 29 type = 161 passing** (+9 vs the
+stand-and-shoot checkpoint: 8 from the new 1" rule suite + 1 from the
+new shorter-diagonal targeting test, with the corner-trap test
+rewritten in place rather than added).
+
+`Board` is now imported in `tests/test_game_engine.gd` alongside
+`Targeting`/`Combat`/`Panic`/`Objectives` — required by the new direct
+unit tests against `Board.validate_move`.
+
+## Design decisions
+
+- **Inline at three call sites, not one mega-helper.** The three
+  modes diverge enough — different allow-list semantics, different
+  exemption rules, different "who counts as a near-unit" predicates —
+  that a unified helper would need a `mode` enum or three flags. Three
+  ~10-line inline checks beat a flag-soup helper. The deliberate
+  duplication mirrors the `objective` check choice from the
+  engine-module-split (board.gd, panic.gd, targeting.gd each do their
+  own objective lookup for the same reason).
+- **Standard mode lives in `Board.validate_move`, not a sibling
+  function.** Both march and move-and-shoot already call
+  `validate_move` for bounds + occupancy + objective. Adding the 1"
+  check there means no caller changes — the validator just got
+  stricter. Charge and retreat needed their own variants because
+  their call paths use different validators (`find_adjacent_cell` and
+  `_is_valid_retreat_dest`).
+- **`d <= 1.0` (inclusive) for "within 1 inch".** A cardinal-adjacent
+  cell is at exactly 1.0 distance and we count it as within 1". Same
+  convention as objective capture (Euclidean ≤1.0). Diagonal-adjacent
+  at 1.41 is outside. This makes the rule match the colloquial reading
+  ("right next to a unit").
+- **Kept `find_adjacent_cell` returning `(-1, -1)` on no-legal-cell
+  rather than throwing or returning a result type.** The sentinel was
+  already there; tightening the legality criteria just narrows the
+  set of cells that pass. Caller already handles sentinel via the
+  "No open cell adjacent to target" error path in `_execute_charge`.
+- **Retreat keeps the `_is_valid_retreat_dest` spiral search.** With
+  the 1" rule added, the spiral may need to expand further before
+  finding a legal cell. The spiral was already 5 layers deep
+  (`for radius in range(1, 6)`); 1"-rule failures within that radius
+  will keep cycling until a >1"-from-everyone cell is found. Did not
+  expand the spiral cap — existing tests pass within radius 5.
+
+## Deferred
+
+- **Deployment 1" rule** (v17 p.9: Followers may not be deployed
+  within 1" of friendly Followers). `place_unit` doesn't go through
+  `validate_move` and has its own bounds/zone/occupancy check. The
+  issue scope was move validation; deployment is a separate code path
+  with a separate sub-clause and minimal interaction (enemies usually
+  aren't on board yet at placement time). Worth a small follow-up PR
+  if it bites in playtest.
+- **Path-not-just-end checking.** The rule wording "A unit may never
+  move within 1\" ... of an enemy model" technically restricts the
+  entire move PATH, not just the end position. Our discrete grid
+  treats movement as teleportation between cells; we only validate
+  the destination. For march/move_and_shoot this is harmless (the
+  path ≤ end position in proximity terms when moves are short
+  Euclidean lines). For retreat the rule explicitly allows
+  passing-through, so we already match that. Charge has a strict
+  end check but no path enforcement; current `find_adjacent_cell`
+  doesn't reason about the swept route.
+- **Detailed error messages.** Errors say "Cannot end move within 1\"
+  of enemy unit (Toff)" with the unit type, which is sufficient for
+  the action_log. If the UI ever wants to highlight the offending
+  unit, the message would need to include the unit ID — currently
+  absent. Not blocking.
+- **Charge "must still move full distance on fail" (#47).** The 1"
+  rule machinery is in place but the related #47 work — chargers that
+  fail to make contact must still move their full charge distance
+  along the shortest route — is the next mechanic, not bundled.
+
+## Board state after
+
+PR #81 closes #46. Audit memory `project_audit_sequencing.md` rotates
+the next pickup to **#47** (charge fail-still-move-full + 1" exception),
+which uses the same machinery added here.
+
+Open mechanics + audit issues:
+
+- **#47** — Charge: fail-still-move-full + 1" exception ← natural next
+  pickup, reuses Board.validate_move + the find_adjacent_cell 1" check
+- **#48** — Snob moves with its commanded unit during order
+- **#49** — Reroll infrastructure (once-only enforcement)
+- **#50** — Vanguard: pre-game free move phase (uses #46 helpers)
+- **#51** — Dash: Whelps free move after order (uses #46 helpers)
+- **#57** — Toff Off! Snob duel mechanic
+- **#58** — Terrain system (Cover/Defensible/Dangerous/Impassable) —
+  large; blocks #62
+- **#59** — Scenario system (objectives, blunders, table layout)
+- **#62** — Dangerous terrain test on retreat through Followers
+  (blocked by #58)
+- **#42** — cult rules audit (pre-deploy)
+
+Bugs / out-of-mechanics:
+
+- **#74** — Battle UI: powder smoke indicator
+- **#72** — Ruleset-version agility audit (pre-v19)
+- **#70, #69, #68, #67, #66, #64** — UX/tooling/infra explorations
+
+No new issues filed this session.
+
+## Next pickup
+
+**#47 — Charge: fail-still-move-full + 1" exception.** v17 p.17:
+"Failed Charges: If it is impossible for any model in the charging
+unit make it into base-to-base contact with the target, they must
+still move towards the target their full charge distance via the
+shortest route possible." Currently `_execute_charge` rejects charges
+that can't reach base contact; under the rule the charger should
+still spend its full charge distance moving toward the target along
+the shortest legal path.
+
+The 1" rule machinery added here is what gates the failed-charge end
+position — even on a failed charge, the unit can't end within 1" of
+non-target units. Reuse `Targeting.find_adjacent_cell`'s 1" filter
+when picking the closest legal cell along the charge vector.
+
+Likely shape:
+
+- Detect failure mode (no `find_adjacent_cell` result OR move_distance
+  > charge_range).
+- Move the charger along the vector toward target, maxing out at
+  charge_range, but stopping at the last legal end position (>1"
+  from any non-target unit, in-bounds, not occupied).
+- No melee, no Stand-and-Shoot, no panic test (the charge is declared
+  but failed to connect — though arguably the target's panic test still
+  fired before the charge-distance roll, per p.16 step 2; check the
+  rules wording carefully).
+- Action log: a new `charge_failed_path` entry with the
+  failed-charge-end position.


### PR DESCRIPTION
## Summary
v17 p.9 + p.17 end-position 1" rule, enforced in three places with three distinct sub-rules:

- **`Board.validate_move`** (march + move_and_shoot, p.9 standard): a Follower may not end within 1" of a friendly Follower; any unit may not end within 1" of an enemy. Snobs are exempt as either mover or near-unit for the friendly check; enemy proximity always counts.
- **`Targeting.find_adjacent_cell`** (charge, p.17 strict): destination must be >1" from any unit except the charge target. No Snob exemption — even friendly Snobs near the candidate cell block it.
- **`Panic._is_valid_retreat_dest`** (retreat, p.9 retreat clause): destination must be >1" from any other unit. No exemptions.

Inline in each path rather than one mega-helper — the three modes diverge enough (allow-list, exemptions, who counts) that flag soup would be uglier than localised duplication.

### Geometry note
On the integer grid with Euclidean distance (per #44):
- Cardinal-adjacent cells are at distance 1.0 — **within 1"** under this rule, illegal.
- Diagonal-adjacent cells are at distance √2 ≈ 1.41 — legal.

### Test changes
- The #77 corner-trap test now asserts the sentinel `(-1, -1)` since strict charge geometry blocks every diagonal in that scenario (each diagonal is exactly 1.0 from a cardinal blocker). Replaced with a **\"shorter-diagonal\"** test that exercises the actual #77 win case: charger at (8,8), target at (10,10), no blockers — diagonal contact at √2 beats the longer cardinal route at 2.24.
- New `_test_one_inch_rule` suite (8 tests): Follower/Follower forbidden, Snob mover exemption, Snob near-unit exemption, enemy proximity always counts (Snob mover doesn't help vs enemies), diagonal-adjacent (1.41) legal, march integration via `execute_order`, charge non-target friendly blocks the cell, retreat dest forbidden within 1\" of a friendly Snob.

Closes #46.

## Test plan
- [x] \`godot --headless -s tests/test_game_engine.gd\` — 132 / 132 passing (8 new 1\" rule tests, 1 #77 test rewritten + 1 added)
- [x] \`godot --headless -s tests/test_runner.gd\` — 29 / 29 passing
- [x] All existing march, move-and-shoot, charge, retreat tests still pass without modification (target positions in those tests were already well-spaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)